### PR TITLE
Respect CC variable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # set gcc as default if CC is not set
-ifndef $CC
+ifndef CC
   CC=gcc
 endif
 


### PR DESCRIPTION
ifndef should use variable-name not the value

https://github.com/rbsec/sslscan/pull/6 add support to use the CC variable, but the ifndef will always overwrite CC to gcc at the moment.
