### PR TITLE
Fix starttls-xmpp

### DIFF
--- a/sslscan.c
+++ b/sslscan.c
@@ -279,7 +279,7 @@ int tcpConnect(struct sslCheckOptions *options)
            expected hostname.
         */
         if (snprintf(xmpp_setup, sizeof(xmpp_setup), "<?xml version='1.0' ?>\r\n"
-               "<stream:stream xmlns:stream='http://etherx.jabber.org/streams' xmlns='jabber:client' to='%s' version='1.0'>\r\n", options->host) >= sizeof(xmpp_setup)) {
+               "<stream:stream xmlns:stream='http://etherx.jabber.org/streams' xmlns='jabber:server' to='%s' version='1.0'>\r\n", options->host) >= sizeof(xmpp_setup)) {
             printf("(internal error: xmpp_setup buffer too small)\n");
             abort();
         }
@@ -307,8 +307,8 @@ int tcpConnect(struct sslCheckOptions *options)
         if (options->verbose)
             printf("Server reported: %s\n", buffer);
 
-        if (!readOrLogAndClose(socketDescriptor, buffer, BUFFERSIZE, options))
-            return 0;
+        //if (!readOrLogAndClose(socketDescriptor, buffer, BUFFERSIZE, options))
+        //    return 0;
         if (strstr(buffer, "<proceed"))
             printf_verbose("It appears that xmpp-tls is ready for TLS.\n");
 


### PR DESCRIPTION
Current code does not complete starttls-xmpp scan.

```
$ ./sslscan --tls12 --starttls-xmpp jbfavre.im:5222
Version: 1.9.11-rbsec-1-g7580d1c-wip-static
OpenSSL 1.0.1m-dev xx XXX xxxx

Testing SSL server jbfavre.im on port 5222

  TLS renegotiation:
    ERROR: error reading from jbfavre.im:5222: Resource temporarily unavailable
ERROR: Could not connect.
```

Had to comment lines 310 & 311 to get things working.
```
$ ./sslscan --tls12 --starttls-xmpp jbfavre.im:5222
Version: 1.9.11-rbsec-1-g7580d1c-static
OpenSSL 1.0.1m-dev xx XXX xxxx

Testing SSL server jbfavre.im on port 5222

  TLS renegotiation:
Session renegotiation not supported

  TLS Compression:
Compression disabled

  Heartbleed:
TLS 1.2 not vulnerable to heartbleed

  Supported Server Cipher(s):
Accepted  TLSv1.2  256 bits  ECDHE-RSA-AES256-GCM-SHA384
Accepted  TLSv1.2  256 bits  ECDHE-RSA-AES256-SHA384
Accepted  TLSv1.2  256 bits  ECDHE-RSA-AES256-SHA
Accepted  TLSv1.2  256 bits  DHE-RSA-AES256-GCM-SHA384
Accepted  TLSv1.2  256 bits  DHE-RSA-AES256-SHA256
Accepted  TLSv1.2  256 bits  DHE-RSA-AES256-SHA
```

Credit goes to @aeris who actually found out what happen and provided a patch