### PR TITLE
Print temporary key parameters - openssl 1.0.2a

### DIFF
--- a/sslscan.h
+++ b/sslscan.h
@@ -172,6 +172,7 @@ ssize_t sendString(int, const char[]);
 int readOrLogAndClose(int, void *, size_t, const struct sslCheckOptions *);
 const char *printableSslMethod(const SSL_METHOD *);
 static int password_callback(char *, int, int, void *);
+int ssl_print_tmp_key(SSL *s);
 
 int tcpConnect(struct sslCheckOptions *);
 int populateCipherList(struct sslCheckOptions *, const SSL_METHOD *);


### PR DESCRIPTION
Copied some code from openssl 1.0.2, and modified a couple of prints. SSLScan will now show the temporary key parameters for elliptic curve keys.

I'm not a real programmer, so this might suck, but I would like this functionality in the final product. Do as you please with it.

Regards,

Frank