### PR TITLE
Fix red background colour (--no-colour)

### DIFF
--- a/sslscan.c
+++ b/sslscan.c
@@ -2914,6 +2914,7 @@ int main(int argc, char *argv[])
             COL_BLUE = "";
             COL_GREEN = "";
             COL_PURPLE = "";
+            COL_RED_BG = "";
         }
 
         // Client Certificates


### PR DESCRIPTION
bug fix
A background becomes the red with "--failed --no-colour" options.
sslscan --failed --no-colour <host>