### PR TITLE
Fix hard exit on bad target in target list

### DIFF
--- a/sslscan.h
+++ b/sslscan.h
@@ -188,6 +188,7 @@ int testCompression(struct sslCheckOptions *, const SSL_METHOD *);
 int testRenegotiation(struct sslCheckOptions *, const SSL_METHOD *);
 int testHeartbleed(struct sslCheckOptions *, const SSL_METHOD *);
 int testCipher(struct sslCheckOptions *, struct sslCipher *);
+int testConnection(struct sslCheckOptions *);
 int testHost(struct sslCheckOptions *);
 
 int loadCerts(struct sslCheckOptions *);


### PR DESCRIPTION
Fixed code so it gracefully moves on to next target if current target in the file doesn't resolve or the port isn't open.

This pull request supersedes a previous pull which had some messy additions from my CDATA pull (and also some unneeded code changes).