### PR TITLE
Sleep < 1000ms does not work

### DIFF
--- a/sslscan.h
+++ b/sslscan.h
@@ -81,6 +81,14 @@ const char *COL_PURPLE = "";
 const char *COL_RED_BG = "";
 #endif
 
+#ifdef _WIN32
+    #define SLEEPMS(ms) Sleep(ms);
+#else
+    #define SLEEPMS(ms) do {                    \
+        struct timeval wait = { 0, ms*1000 };   \
+        select(0, NULL, NULL, NULL, &wait);     \
+    } while(0)
+#endif
 
 const char *program_banner = "                   _\n"
                              "           ___ ___| |___  ___ __ _ _ __\n"
@@ -140,7 +148,7 @@ struct sslCheckOptions
     struct sockaddr_in serverAddress;
     struct sockaddr_in6 serverAddress6;
     struct timeval timeout;
-    struct timespec sleep;
+    unsigned int sleep;
 
     // SSL Variables...
     SSL_CTX *ctx;


### PR DESCRIPTION
Hi,

I've encountered a problem with the `--sleep` flag: It does not honor values below 1s (in fact, it only sleeps for full seconds).

At first, I thought the comiler had optimized out this construct:

```c
options.sleep.tv_sec = msec / 1000;
options.sleep.tv_nsec = (msec - (options.sleep.tv_sec * 1000)) * 1000000;
```

(where `msec - msec/1000 *1000` is mathematically equal to 0), but changing it to

```c
options.sleep.tv_sec = msec / 1000;
options.sleep.tv_nsec = (msec % 1000) * 1000000;
```

did not bring the expected result. So I replaced the `nanosleep`-call with a more robust implementation I use in other projects as well:

```c
struct timeval wait = { 0, msec*1000 };
select(0, NULL, NULL, NULL, &wait);
```

I'm not sure, whether this will compile or run on Windows (it should though, the `--sleep` value is directly fed to `Sleep` function), so another pair of eyes could be helpful.

Regards,
Dominik