### PR TITLE
Handle building on OpenBSD

### DIFF
--- a/sslscan.c
+++ b/sslscan.c
@@ -83,7 +83,7 @@
   #include <unistd.h>
 #endif
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <netinet/in.h>
 #endif
 

--- a/sslscan.c
+++ b/sslscan.c
@@ -1134,7 +1134,7 @@ int testHeartbleed(struct sslCheckOptions *options, const SSL_METHOD *sslMethod)
 
 int ssl_print_tmp_key(struct sslCheckOptions *options, SSL *s)
 {
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)
     EVP_PKEY *key;
     if (!SSL_get_server_tmp_key(s, &key))
         return 1;


### PR DESCRIPTION
Handle building on OpenBSD, needs netinet/in.h (whether built against libressl or openssl), and libressl builds need different OPENSSL_VERSION_NUMBER handling.