### PR TITLE
Makefile: label install and other phony targets as .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ LDFLAGS   += -L/usr/local/ssl/lib/ -L/usr/local/opt/openssl/lib
 CFLAGS    += -I/usr/local/ssl/include/ -I/usr/local/ssl/include/openssl/ -I/usr/local/opt/openssl/include
 endif
 
-.PHONY: sslscan clean
+.PHONY: all sslscan clean install uninstall static
 
 all: sslscan
 	@echo
@@ -51,7 +51,7 @@ all: sslscan
 sslscan: $(SRCS)
 	$(CC) -o $@ ${WARNINGS} ${LDFLAGS} ${CFLAGS} ${CPPFLAGS} ${DEFINES} ${SRCS} ${LIBS}
 
-install:
+install: sslscan
 	mkdir -p $(BINPATH)
 	mkdir -p $(MANPATH)man1/
 	cp sslscan $(BINPATH)


### PR DESCRIPTION
This PR explicitly labels all the phony targets as .PHONY, to avoid files with those names making `make` think the targets are already satisfied.

In particular, on Mac OS X, the filesystem is case insensitive by default. So the `INSTALL` text file in the source tree will look like it satisfies the `install` target, and `make install` will do nothing.