### PR TITLE
Makefile: add PREFIX support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,10 @@ endif
 OS := $(shell uname)
 
 SRCS      = sslscan.c
-BINPATH   = $(DESTDIR)/usr/bin/
-MANPATH   = $(DESTDIR)/usr/share/man/
+PREFIX    = /usr
+BINDIR    = $(PREFIX)/bin
+MANDIR    = $(PREFIX)/share/man
+MAN1DIR   = $(MANDIR)/man1
 
 WARNINGS  = -Wall -Wformat=2
 DEFINES   = -DVERSION=\"$(GIT_VERSION)\"
@@ -52,14 +54,14 @@ sslscan: $(SRCS)
 	$(CC) -o $@ ${WARNINGS} ${LDFLAGS} ${CFLAGS} ${CPPFLAGS} ${DEFINES} ${SRCS} ${LIBS}
 
 install:
-	mkdir -p $(BINPATH)
-	mkdir -p $(MANPATH)man1/
-	cp sslscan $(BINPATH)
-	cp sslscan.1 $(MANPATH)man1/
+	mkdir -p $(DESTDIR)$(BINDIR)
+	mkdir -p $(DESTDIR)$(MAN1DIR)
+	cp sslscan $(DESTDIR)$(BINDIR)
+	cp sslscan.1 $(DESTDIR)$(MAN1DIR)
 
 uninstall:
-	rm -f $(BINPATH)sslscan
-	rm -f $(MANPATH)man1/sslscan.1
+	rm -f $(DESTDIR)$(BINDIR)/sslscan
+	rm -f $(DESTDIR)$(MAN1DIR)/sslscan.1
 
 openssl/Makefile:
 	[ -d openssl -a -d openssl/.git ] && true || git clone https://github.com/openssl/openssl ./openssl && cd ./openssl && git checkout OpenSSL_1_0_2-stable


### PR DESCRIPTION
Here's a suggestion/request for a tweak to sslscan's Makefile to make it easier for users and packagers to install it to other locations besides `/usr`. This is based on our [experience installing `sslscan` using Mac Homebrew](https://github.com/Homebrew/homebrew/pull/47229).

This PR:

- Adds support for the `PREFIX` variable, to allow convenient relocation of the entire installation. This is easier for users than having to specify both `BINDIR` and `MANDIR`, and will cover libs and headers and other things if they get added in the future. `PREFIX` is the conventional variable for doing wholesale changes to the installation location like this.

- Renames `BINPATH` and `MANPATH` to `BINDIR` and `MANDIR`. `DIR` is the conventional suffix for these in [GNU Makefiles](https://www.gnu.org/prep/standards/html_node/Directory-Variables.html). Variables ending in `PATH` typically indicate a search path of multiple directories. `MANPATH` in particular is used as a search path and often exported, so this original Makefile could have problems if a user actually has a multi-element `MANPATH` (e.g. with Homebrew or MacPorts).

- Keeps `DESTDIR` around, but moves it down into the `install` and `uninstall` targets, so it works with `PREFIX` in the [conventional GNU manner](https://www.gnu.org/prep/standards/html_node/DESTDIR.html) for doing "staged" installations.

- Uses slashes between `$(XXXDIR)` references so they work even if the user supplies a value that doesn't end in a trailing slash. (Exception is `$(DESTDIR)`, which may be empty.)