### PR TITLE
Added git pull for openssl on static builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ libssl*
 
 # custom openssl build
 openssl/
+.openssl.is.fresh


### PR DESCRIPTION
Currently, once you've built sslscan with make static the openssl repository never gets updated on consequent builds (not even if you run make clean).
The pull-request adresses this, and runs git pull on any make static invocation - a cookie file (.openssl.is.fresh) ensures, hat openssl is only rebuild, if changes were made.