### PR TITLE
enable SSLv2 when configuring openssl for static builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ openssl/Makefile: .openssl.is.fresh
 # Any other *NIX platform
 else
 openssl/Makefile: .openssl.is.fresh
-	cd ./openssl; ./config no-shares
+	cd ./openssl; ./config no-shares enable-ssl2
 endif
 
 openssl/libcrypto.a: openssl/Makefile


### PR DESCRIPTION
Add SSLv2 support to the openssl we build with 'make static'.