### PR TITLE
Fix compression detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ifeq ($(STATIC_BUILD), TRUE)
 PWD          = $(shell pwd)/openssl
 LDFLAGS      += -L${PWD}/
 CFLAGS       += -I${PWD}/include/ -I${PWD}/
-LIBS         = -lssl -lcrypto -ldl
+LIBS         = -lssl -lcrypto -ldl -lz
 GIT_VERSION  := $(GIT_VERSION)-static
 else
 # for dynamic linking
@@ -80,7 +80,7 @@ openssl/Makefile: .openssl.is.fresh
 # Any other *NIX platform
 else
 openssl/Makefile: .openssl.is.fresh
-	cd ./openssl; ./config no-shares enable-weak-ssl-ciphers enable-ssl2
+	cd ./openssl; ./config no-shares enable-weak-ssl-ciphers enable-ssl2 zlib
 endif
 
 openssl/libcrypto.a: openssl/Makefile

--- a/sslscan.c
+++ b/sslscan.c
@@ -720,6 +720,11 @@ int testCompression(struct sslCheckOptions *options, const SSL_METHOD *sslMethod
                     SSL_set_options(ssl, SSL_OP_LEGACY_SERVER_CONNECT);
 #endif
 
+#ifdef SSL_OP_NO_COMPRESSION
+                    // Make sure to clear the no compression flag
+                    SSL_clear_options(ssl, SSL_OP_NO_COMPRESSION);
+#endif
+
                    if (ssl != NULL)
                     {
                         // Connect socket and BIO


### PR DESCRIPTION
Three issues here:

1. sslscan wasn't clearing SSL_OP_NO_COMPRESSION which may be set by default in some builds of OpenSSL
2. sslscan wasn't verifying that COMP_zlib support was actually present
3. The static build of openssl wasn't building zlib support