### PR TITLE
linking fix and osx compile fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ WARNINGS  = -Wall -Wformat=2
 DEFINES   = -DVERSION=\"$(GIT_VERSION)\"
 
 # for dynamic linking
-LIBS      = -lssl -lcrypto
+LIBS      = -lssl -lcrypto -ldl
 
 # for static linking
 ifeq ($(STATIC_BUILD), TRUE)

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ LIBS         = -lssl -lcrypto -ldl -lz
 GIT_VERSION  := $(GIT_VERSION)-static
 else
 # for dynamic linking
-LDFLAGS   += -L/usr/local/ssl/lib/ -L/usr/local/opt/openssl/lib
-CFLAGS    += -I/usr/local/ssl/include/ -I/usr/local/ssl/include/openssl/ -I/usr/local/opt/openssl/include
+LDFLAGS   += -L/usr/local/ssl/lib/ -L/usr/local/opt/openssl/lib -L/opt/local/lib
+CFLAGS    += -I/usr/local/ssl/include/ -I/usr/local/ssl/include/openssl/ -I/usr/local/opt/openssl/include -I/opt/local/include/ -I/opt/local/include/openssl/
 endif
 
 .PHONY: all sslscan clean install uninstall static opensslpull


### PR DESCRIPTION
Some people use self compiled openssl libs they want to link against, but `make` fails, because their openssl libs are only static. a7227e3 fixes this. This should be done by `make static` but the current `make static` pulls and compiles its own openssl. (It should rather be called `make static-and-openssl`.)

On OSX the MacPorts openssl is in `/opt/local/...`, thus I've added the correct paths (ef13d8a).
