### PR TITLE
make: do not link against libdl on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,14 +23,20 @@ WARNINGS  = -Wall -Wformat=2
 DEFINES   = -DVERSION=\"$(GIT_VERSION)\"
 
 # for dynamic linking
-LIBS      = -lssl -lcrypto -ldl
+LIBS      = -lssl -lcrypto
+ifneq ($(OS), FreeBSD)
+	LIBS += -ldl
+endif
 
 # for static linking
 ifeq ($(STATIC_BUILD), TRUE)
 PWD          = $(shell pwd)/openssl
 LDFLAGS      += -L${PWD}/
 CFLAGS       += -I${PWD}/include/ -I${PWD}/
-LIBS         = -lssl -lcrypto -ldl -lz
+LIBS         = -lssl -lcrypto -lz
+ifneq ($(OS), FreeBSD)
+	LIBS += -ldl
+endif
 GIT_VERSION  := $(GIT_VERSION)-static
 else
 # for dynamic linking


### PR DESCRIPTION
On FreeBSD libdl is already included in libc.

See http://lists.freebsd.org/pipermail/freebsd-questions/2008-March/172079.html
and https://github.com/primecoin/primecoin/pull/22.

This PR requires  #90 to be merged first to work properly.

Verified compilation on

FreeBSD 9.3-RELEASE:

    $ uname -a
    FreeBSD <hostname> 9.3-STABLE FreeBSD 9.3-STABLE #68 r296980: Thu Mar 17 09:24:08 CET 2016     root@<hostname>:/usr/obj/usr/src/sys/BLNN719X  i386
    $ gmake
    cc -o sslscan -Wall -Wformat=2 -L/usr/local/lib -L/usr/local/ssl/lib/ -L/usr/local/opt/openssl/lib -L/opt/local/lib -I/usr/local/include -I/usr/local/ssl/include/ -I/usr/local/ssl/include/openssl/ -I/usr/local/opt/openssl/include -I/opt/local/include/ -I/opt/local/include/openssl/  -DVERSION=\"1.11.4-rbsec-10-gc24d8f6-wip\" sslscan.c -lssl -lcrypto
    
    ===========
    | WARNING |
    ===========
    
    Building against system OpenSSL. Legacy protocol checks may not be possible.
    It is recommended that you statically build sslscan with  `make static`.

and RHEL 6.7:

    $ uname -a
    Linux <hostname> 2.6.32-573.18.1.el6.x86_64 #1 SMP Wed Jan 6 11:20:49 EST 2016 x86_64 x86_64 x86_64 GNU/Linux
    $ gmake
    gmake: git: Kommando nicht gefunden
    cc -o sslscan -Wall -Wformat=2 -L/usr/local/lib -L/usr/local/ssl/lib/ -L/usr/local/opt/openssl/lib -L/opt/local/lib -I/usr/local/include -I/usr/local/ssl/include/ -I/usr/local/ssl/include/openssl/ -I/usr/local/opt/openssl/include -I/opt/local/include/ -I/opt/local/include/openssl/  -DVERSION=\"1.11.4\" sslscan.c -lssl -lcrypto -ldl
    
    ===========
    | WARNING |
    ===========
    
    Building against system OpenSSL. Legacy protocol checks may not be possible.
    It is recommended that you statically build sslscan with  `make static`.



