### PR TITLE
Add -d flag to install for MacOS, to create missing dirs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ install:
 		exit 1; \
 	fi
 ifeq ($(OS), Darwin)
-	install sslscan $(DESTDIR)$(BINDIR)/sslscan;
-	install sslscan.1 $(DESTDIR)$(MAN1DIR)/sslscan.1;
+	install -d sslscan $(DESTDIR)$(BINDIR)/sslscan;
+	install -d sslscan.1 $(DESTDIR)$(MAN1DIR)/sslscan.1;
 else
 	install -D sslscan $(DESTDIR)$(BINDIR)/sslscan;
 	install -D sslscan.1 $(DESTDIR)$(MAN1DIR)/sslscan.1;


### PR DESCRIPTION
'make install' fails for Homebrew users, because it installs to directories that usually don't exist in advance. Adding the -d flag tells 'install' to create the directories as needed.