### PR TITLE
Re-enable weak DH keys in openssl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,8 @@ opensslpull:
 	fi
 	sed -i.bak 's/# if 0/# if 1/g' openssl/ssl/s2_lib.c
 	rm openssl/ssl/s2_lib.c.bak
+	sed -i.bak 's/dh_size < [0-9]\+/dh_size < 768/g' openssl/ssl/s3_clnt.c
+	rm openssl/ssl/s3_clnt.c.bak
 
 # Need to build OpenSSL differently on OSX
 ifeq ($(OS), Darwin)


### PR DESCRIPTION
768-bits is enough to detect DHE enabled in Java 6/7 servers.

I wanted to set this all the way down to 512-bits, but that broke the openssl test suite which explicitly tests for a failure on that size. When I figure out a simple way to disable that test I'll either update this pull request or post a new one.