### PR TITLE
Remove green highlighting from non-PFS GCM suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a fork of ioerror's version of sslscan (the original readme of which is 
 * Highlight SSLv2 and SSLv3 ciphers in output.
 * Highlight CBC ciphers on SSLv3 (POODLE)
 * Highlight RC4 ciphers in output.
-* Highlight GCM ciphers as good in output.
+* Highlight PFS+GCM ciphers as good in output.
 * Highlight NULL (0 bit), weak (<40 bit) and medium (40 < n <= 56) ciphers in output.
 * Highlight anonymous (ADH and AECDH) ciphers in output (purple).
 * Hide certificate information by default (display with --get-certificate).

--- a/sslscan.c
+++ b/sslscan.c
@@ -1424,7 +1424,7 @@ int testCipher(struct sslCheckOptions *options, const SSL_METHOD *sslMethod)
                 {
                     printf("%s%-29s%s", COL_YELLOW, sslCipherPointer->name, RESET);
                 }
-                else if (strstr(sslCipherPointer->name, "GCM"))
+                else if (strstr(sslCipherPointer->name, "GCM") && strstr(sslCipherPointer->name, "DHE"))
                 {
                     printf("%s%-29s%s", COL_GREEN, sslCipherPointer->name, RESET);
                 }


### PR DESCRIPTION
IMHO both PFS and GCM are needed to deserve the green status.