### PR TITLE
'install -d' only takes a directory as an argument, fix #102

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,10 @@ install:
 		exit 1; \
 	fi
 ifeq ($(OS), Darwin)
-	install -d sslscan $(DESTDIR)$(BINDIR)/sslscan;
-	install -d sslscan.1 $(DESTDIR)$(MAN1DIR)/sslscan.1;
+	install -d $(DESTDIR)$(BINDIR)/;
+	install sslscan $(DESTDIR)$(BINDIR)/sslscan;
+	install -d $(DESTDIR)$(MAN1DIR)/;
+	install sslscan.1 $(DESTDIR)$(MAN1DIR)/sslscan.1;
 else
 	install -D sslscan $(DESTDIR)$(BINDIR)/sslscan;
 	install -D sslscan.1 $(DESTDIR)$(MAN1DIR)/sslscan.1;


### PR DESCRIPTION
fixes #102

beginning of man page for install on BSD / OSX:

```
NAME
     install -- install binaries

SYNOPSIS
     install [-bCcMpSsv] [-B suffix] [-f flags] [-g group] [-m mode] [-o owner] file1 file2
     install [-bCcMpSsv] [-B suffix] [-f flags] [-g group] [-m mode] [-o owner] file1 ... fileN directory
     install -d [-v] [-g group] [-m mode] [-o owner] directory ...
```

`install -d` only takes a directory as an argument