### PR TITLE
Add STARTTLS for LDAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This is a fork of ioerror's version of sslscan (the original readme of which is 
 * Experimental OSX support (static building only)
 * Support for scanning PostgreSQL servers (credit nuxi)
 * Check for TLS Fallback SCSV support
+* Added StartTLS support for LDAP (--starttls-ldap)
 
 ### Building on Windows
 Thanks to a patch by jtesta, sslscan can now be compiled on Windows. This can

--- a/TODO
+++ b/TODO
@@ -5,8 +5,6 @@ Fix the certificate formatting (prefix it with whitespace)
 Add support for SOCKS5 proxy (or audit for 'usewithtor')
     It seems to work fine with 'usewithtor'
     It still seems prudent to add proper proxy support
-Add STARTTLS support for LDAP:
-    http://www.rfc-editor.org/rfc/rfc2830.txt
 Fix XMPP scans that do not support StartTLS:
     "<stream:error><invalid-namespace xmlns='urn:ietf:params:xml:ns:xmpp-streams'/></stream:error>"
 Add HTML report generation

--- a/sslscan.1
+++ b/sslscan.1
@@ -136,6 +136,9 @@ STARTTLS setup for IRC
 .B \-\-starttls\-imap
 STARTTLS setup for IMAP
 .TP
+.B \-\-starttls\-ldap
+STARTTLS setup for LDAP
+.TP
 .B \-\-starttls\-pop3
 STARTTLS setup for POP3
 .TP

--- a/sslscan.h
+++ b/sslscan.h
@@ -129,6 +129,7 @@ struct sslCheckOptions
     int starttls_ftp;
     int starttls_imap;
     int starttls_irc;
+    int starttls_ldap;
     int starttls_pop3;
     int starttls_smtp;
     int starttls_xmpp;


### PR DESCRIPTION
The patch provides a simple implementation of RFC 2830 STARTTLS for
LDAP. The LDAPv3 ExtendedRequest with OID 1.3.6.1.4.1.1466.20037 is
hard-coded.

Tested with 389-DS and OpenLDAP.

Signed-off-by: Christian Heimes <cheimes@redhat.com>