### PR TITLE
Fixed Windows build system.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ libssl*
 # custom openssl build
 openssl/
 .openssl.is.fresh
+.openssl_mingw.is.fresh

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ libssl*
 openssl/
 .openssl.is.fresh
 .openssl_mingw.is.fresh
+
+# custom zlib build for Windows
+zlib_mingw/

--- a/INSTALL
+++ b/INSTALL
@@ -14,13 +14,11 @@ Manual Build:
 
 ----
 
-There are three ways to build a Windows executable:
+There are two ways to build a Windows executable:
 
   1.) By cross-compiling on a Linux build machine using MinGW or Mingw-w64.
 
-  2.) By compiling on a Windows build machine using MinGW or Mingw-w64.
-
-  3.) By compiling on a Windows build machine using Visual Studio 2013
+  2.) By compiling on a Windows build machine using Visual Studio 2013
       (other versions may also work, but are untested).
 
   If you have a Debian-like Linux machine (such as Ubuntu or Kali), option
@@ -40,15 +38,9 @@ I. Cross-compiling from Linux
     0.) Install Mingw-w64.  On Debian-like systems, this can be done with:
         apt-get install mingw-w64
 
-    1.) Download and compile OpenSSL with the following:
-	git clone https://github.com/openssl/openssl
-	git checkout OpenSSL_1_0_2-stable
-        ./Configure --cross-compile-prefix=x86_64-w64-mingw32- \
-            -fstack-protector-all -D_FORTIFY_SOURCE=2 mingw64 shared
-        make
-
-    2.) Compile sslscan with the path to the OpenSSL directory:
-        make -f Makefile.mingw OPENSSL_PATH=../path/to/openssl
+    1.) Compile sslscan.  It will download the OpenSSL sources from GitHub
+        automatically:
+        make -f Makefile.mingw
 
 
   B. Building a 32-bit Windows executable
@@ -56,48 +48,12 @@ I. Cross-compiling from Linux
     0.) Install MinGW.  On Debian-like systems, this can be done with:
         apt-get install mingw32
 
-    1.) Download and compile OpenSSL with the following:
-	git clone https://github.com/openssl/openssl
-	git checkout OpenSSL_1_0_2-stable
-        ./Configure --cross-compile-prefix=i586-mingw32msvc- \
-            -fstack-protector-all -D_FORTIFY_SOURCE=2 mingw shared
-        make
-
-    2.) Compile sslscan with the path to the OpenSSL directory:
-        DEFINES="-DWONKY_LINUX_MINGW=1" make -f Makefile.mingw \
-            OPENSSL_PATH=../path/to/openssl
+    1.) Compile sslscan.  It will download the OpenSSL sources from GitHub
+        automatically:
+        make -f Makefile.mingw BUILD_32BIT=1
 
 
-II. Compiling on Windows using Mingw
-
-  A. Building a 64-bit Windows executable
-
-    0.) Install Mingw-w64 from http://mingw-w64.sourceforge.net/.  Install
-        MSYS from http://www.mingw.org/.
-
-    1.) In an MSYS shell, compile OpenSSL with the following:
-       ./Configure mingw64 -fstack-protector-all -D_FORTIFY_SOURCE=2 shared
-       make
-
-    2.) In an MSYS shell, compile sslscan with the path to the OpenSSL
-           directory:
-       make -f Makefile.mingw OPENSSL_PATH=../path/to/openssl
-
-
-  B. Building a 32-bit Windows executable
-
-    0.) Install MinGW and MSYS from http://www.mingw.org/.
-
-    1.) In an MSYS shell, compile OpenSSL with the following:
-       ./Configure mingw -fstack-protector-all -D_FORTIFY_SOURCE=2 shared
-       make
-
-    2.) In an MSYS shell, compile sslscan with the path to the OpenSSL
-           directory:
-       make -f Makefile.mingw OPENSSL_PATH=../path/to/openssl
-
-
-III. Compiling on Windows using Visual Studio 2013 Express for Windows Desktop
+II. Compiling on Windows using Visual Studio 2013 Express for Windows Desktop
 
   A. Install Visual Studio 2013 Express for Windows Desktop:
          http://go.microsoft.com/?linkid=9832280

--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -1,18 +1,38 @@
+#
+# To build a 64-bit executable:  make -f Makefile.mingw
+# To build a 32-bit executable:  make -f Makefile.mingw BUILD_32BIT=1
+#
+
+
+# Enable to echo commands for debugging.
+#SHELL = sh -xv
+
 # If we're in Linux, lets see if we can find the path to Mingw automatically...
+ARCHITECTURE=??-bit
+OPENSSL_CC_PREFIX=
+OPENSSL_TARGET=
 ifeq ($(shell uname), Linux)
   MINGW32=$(shell which i586-mingw32msvc-gcc)
   ifneq ($(MINGW32),)
     CC=$(MINGW32)
+    ARCHITECTURE=32-bit
+    OPENSSL_CC_PREFIX=i586-mingw32msvc-
+    OPENSSL_TARGET=mingw
   endif
 
   MINGW64=$(shell which x86_64-w64-mingw32-gcc)
   ifneq ($(MINGW64),)
-    CC=$(MINGW64)
+    ifeq ($(BUILD_32BIT),)
+      CC=$(MINGW64)
+      ARCHITECTURE=64-bit
+      OPENSSL_CC_PREFIX=x86_64-w64-mingw32-
+      OPENSSL_TARGET=mingw64
+    endif
   endif
 endif
 
 ifndef CC
-  CC=gcc
+  $(error "Failed to determine the compiler!")
 endif
 
 .PHONY: clean
@@ -23,11 +43,8 @@ SECURITY_OPTIONS=-fstack-protector-all -D_FORTIFY_SOURCE=2 -Wformat -Wformat-sec
 # Turn on linker optimizations, and DEP support (--nxcompat)
 LINK_OPTIONS=-Wl,-O1 -Wl,--discard-all -Wl,--no-undefined -Wl,--dynamicbase -Wl,--nxcompat -static
 
-# Set ARCHITECTURE to either x86 or x86_64...
-ARCHITECTURE=32-bit
-ifeq ($(shell $(CC) -dumpmachine), x86_64-w64-mingw32)
-  ARCHITECTURE=64-bit
-endif
+CFLAGS += -Iopenssl_mingw/include -D__USE_GNU
+LDFLAGS += -lws2_32 -lgdi32
 
 # Set the version string for the program.
 VERSION = "$(shell grep -E -o -m 1 "[0-9]+\.[0-9]+\.[0-9]+" Changelog) Windows $(ARCHITECTURE) (Mingw)"
@@ -35,9 +52,26 @@ VERSION = "$(shell grep -E -o -m 1 "[0-9]+\.[0-9]+\.[0-9]+" Changelog) Windows $
 
 all: sslscan
 
-sslscan: sslscan.c
-	$(CC) -I$(OPENSSL_PATH)/include -DVERSION=\"$(VERSION)\" $(DEFINES) $(SECURITY_OPTIONS) $(LINK_OPTIONS) -o sslscan.exe sslscan.c $(OPENSSL_PATH)/libssl.a $(OPENSSL_PATH)/libcrypto.a -lws2_32 -lgdi32
+.openssl_mingw.is.fresh: opensslpull
+	true
+
+opensslpull:
+	if [ -d openssl_mingw -a -d openssl_mingw/.git ]; then \
+		cd ./openssl_mingw && git checkout OpenSSL_1_0_2-stable && git pull | grep -q "Already up-to-date." && [ -e ../.openssl_mingw.is.fresh ] || touch ../.openssl_mingw.is.fresh ; \
+	else \
+		git clone --depth 1 -b OpenSSL_1_0_2-stable https://github.com/openssl/openssl ./openssl_mingw && cd ./openssl_mingw && touch ../.openssl_mingw.is.fresh ; \
+	fi
+
+openssl_mingw/Makefile: .openssl_mingw.is.fresh
+	cd ./openssl_mingw; ./Configure --cross-compile-prefix=$(OPENSSL_CC_PREFIX) -fstack-protector-all -D_FORTIFY_SOURCE=2 $(OPENSSL_TARGET) no-shared enable-weak-ssl-ciphers enable-ssl2
+
+openssl_mingw/libcrypto.a: openssl_mingw/Makefile
+	$(MAKE) -C openssl_mingw depend
+	$(MAKE) -j 10 -C openssl_mingw all
+
+sslscan: openssl_mingw/libcrypto.a sslscan.c
+	$(CC) $(CFLAGS) -DVERSION=\"$(VERSION)\" $(DEFINES) $(SECURITY_OPTIONS) $(LINK_OPTIONS) -o sslscan.exe sslscan.c openssl_mingw/libssl.a openssl_mingw/libcrypto.a $(LDFLAGS)
 	strip sslscan.exe
 
 clean:
-	rm -f *.o sslscan.exe
+	rm -f *.o sslscan.exe .openssl_mingw.is.fresh && $(MAKE) -C openssl_mingw clean

--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -8,15 +8,15 @@
 #SHELL = sh -xv
 
 # If we're in Linux, lets see if we can find the path to Mingw automatically...
-ARCHITECTURE=??-bit
-OPENSSL_CC_PREFIX=
+ARCHITECTURE=
+CC_PREFIX=
 OPENSSL_TARGET=
 ifeq ($(shell uname), Linux)
   MINGW32=$(shell which i586-mingw32msvc-gcc)
   ifneq ($(MINGW32),)
     CC=$(MINGW32)
     ARCHITECTURE=32-bit
-    OPENSSL_CC_PREFIX=i586-mingw32msvc-
+    CC_PREFIX=i586-mingw32msvc-
     OPENSSL_TARGET=mingw
   endif
 
@@ -25,7 +25,7 @@ ifeq ($(shell uname), Linux)
     ifeq ($(BUILD_32BIT),)
       CC=$(MINGW64)
       ARCHITECTURE=64-bit
-      OPENSSL_CC_PREFIX=x86_64-w64-mingw32-
+      CC_PREFIX=x86_64-w64-mingw32-
       OPENSSL_TARGET=mingw64
     endif
   endif
@@ -38,6 +38,8 @@ endif
 .PHONY: clean
 
 # Enable security options like stack protectors and variable formatting checks.
+# Sadly, we can't use -pie, because MinGW produces a broken executable when
+# enabled.
 SECURITY_OPTIONS=-fstack-protector-all -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security
 
 # Turn on linker optimizations, and DEP support (--nxcompat)
@@ -55,23 +57,36 @@ all: sslscan
 .openssl_mingw.is.fresh: opensslpull
 	true
 
+zlibpull:
+#	If the zlib dir already exists, issue a pull, otherwise clone it from GitHub.  Either way, check out the latest tag.
+	if [ -d zlib_mingw -a -d zlib_mingw/.git ]; then \
+		cd ./zlib_mingw && git pull && git checkout tags/`git describe --abbrev=0 --tags` ; \
+	else \
+		git clone --depth 1 https://github.com/madler/zlib ./zlib_mingw && cd ./zlib_mingw && git checkout tags/`git describe --abbrev=0` ; \
+	fi
+
 opensslpull:
 	if [ -d openssl_mingw -a -d openssl_mingw/.git ]; then \
 		cd ./openssl_mingw && git checkout OpenSSL_1_0_2-stable && git pull | grep -q "Already up-to-date." && [ -e ../.openssl_mingw.is.fresh ] || touch ../.openssl_mingw.is.fresh ; \
 	else \
-		git clone --depth 1 -b OpenSSL_1_0_2-stable https://github.com/openssl/openssl ./openssl_mingw && cd ./openssl_mingw && touch ../.openssl_mingw.is.fresh ; \
+		git clone --depth 1 -b OpenSSL_1_0_2-stable https://github.com/PeterMosmans/openssl ./openssl_mingw && cd ./openssl_mingw && touch ../.openssl_mingw.is.fresh ; \
 	fi
 
-openssl_mingw/Makefile: .openssl_mingw.is.fresh
-	cd ./openssl_mingw; ./Configure --cross-compile-prefix=$(OPENSSL_CC_PREFIX) -fstack-protector-all -D_FORTIFY_SOURCE=2 $(OPENSSL_TARGET) no-shared enable-weak-ssl-ciphers enable-ssl2
+zlib_mingw/libz.a: zlibpull
+	cd ./zlib_mingw; make -f win32/Makefile.gcc PREFIX=$(CC_PREFIX)
+
+openssl_mingw/Makefile: .openssl_mingw.is.fresh zlib_mingw/libz.a
+	cd ./openssl_mingw; ./Configure --cross-compile-prefix=$(CC_PREFIX) --with-zlib-include=`pwd`/../zlib_mingw --with-zlib-lib=`pwd`/../zlib_mingw -fstack-protector-all -D_FORTIFY_SOURCE=2 $(OPENSSL_TARGET) no-shared enable-weak-ssl-ciphers enable-ssl2 zlib
 
 openssl_mingw/libcrypto.a: openssl_mingw/Makefile
 	$(MAKE) -C openssl_mingw depend
 	$(MAKE) -j 10 -C openssl_mingw all
 
 sslscan: openssl_mingw/libcrypto.a sslscan.c
-	$(CC) $(CFLAGS) -DVERSION=\"$(VERSION)\" $(DEFINES) $(SECURITY_OPTIONS) $(LINK_OPTIONS) -o sslscan.exe sslscan.c openssl_mingw/libssl.a openssl_mingw/libcrypto.a $(LDFLAGS)
-	strip sslscan.exe
+	$(CC) $(CFLAGS) -DVERSION=\"$(VERSION)\" $(DEFINES) $(SECURITY_OPTIONS) $(LINK_OPTIONS) -o sslscan.exe sslscan.c openssl_mingw/libssl.a openssl_mingw/libcrypto.a zlib_mingw/libz.a $(LDFLAGS)
+	$(CC_PREFIX)strip sslscan.exe
 
 clean:
-	rm -f *.o sslscan.exe .openssl_mingw.is.fresh && $(MAKE) -C openssl_mingw clean
+	rm -f *.o sslscan.exe .openssl_mingw.is.fresh
+	if [ -f openssl_mingw/Makefile ]; then $(MAKE) -C openssl_mingw clean; fi
+	if [ -f zlib_mingw/win32/Makefile.gcc ]; then $(MAKE) -C zlib_mingw -f win32/Makefile.gcc clean; fi


### PR DESCRIPTION
Cross-compiling a Windows executable from Linux is now possible again.  The build system automatically pulls and compiles the OpenSSL sources from GitHub just like the UNIX build system does too.