### PR TITLE
Make --show-times option reflect --no-colour option

### DIFF
--- a/sslscan.c
+++ b/sslscan.c
@@ -3527,6 +3527,7 @@ int main(int argc, char *argv[])
             COL_GREEN = "";
             COL_PURPLE = "";
             COL_RED_BG = "";
+            COL_GREY = "";
         }
 
         // Client Certificates


### PR DESCRIPTION
The output of --show-times option is colored even if --no-colour option is specified.