### PR TITLE
Added Windows builds to Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,15 @@ sudo: required
 dist: trusty
 language: c
 
-compiler:
-  - clang
-  - gcc
-
-env:
-  - TARGET=sslscan
-  - TARGET=static
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq mingw-w64
 
 script:
-  - make $TARGET CC=$CC
-
-matrix:
-  exclude:
-    # OpenSSL can't be compiled out-of-the box with clang, see
-    # http://wiki.openssl.org/index.php/Compilation_and_Installation#Modifying_Build_Settings
-    - compiler: clang
-      env: TARGET=static
+  - make sslscan CC=clang
+  - make sslscan CC=gcc
+  # OpenSSL can't be compiled out-of-the box with clang, see
+  # http://wiki.openssl.org/index.php/Compilation_and_Installation#Modifying_Build_Settings
+  #- make static CC=clang
+  - make static CC=gcc
+  - make -f Makefile.mingw

--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -79,8 +79,8 @@ openssl_mingw/Makefile: .openssl_mingw.is.fresh zlib_mingw/libz.a
 	cd ./openssl_mingw; ./Configure --cross-compile-prefix=$(CC_PREFIX) --with-zlib-include=`pwd`/../zlib_mingw --with-zlib-lib=`pwd`/../zlib_mingw -fstack-protector-all -D_FORTIFY_SOURCE=2 $(OPENSSL_TARGET) no-shared enable-weak-ssl-ciphers enable-ssl2 zlib
 
 openssl_mingw/libcrypto.a: openssl_mingw/Makefile
-	$(MAKE) -C openssl_mingw depend
-	$(MAKE) -j 10 -C openssl_mingw all
+	$(MAKE) -C openssl_mingw depend CC=$(CC)
+	$(MAKE) -j 10 -C openssl_mingw all CC=$(CC)
 
 sslscan: openssl_mingw/libcrypto.a sslscan.c
 	$(CC) $(CFLAGS) -DVERSION=\"$(VERSION)\" $(DEFINES) $(SECURITY_OPTIONS) $(LINK_OPTIONS) -o sslscan.exe sslscan.c openssl_mingw/libssl.a openssl_mingw/libcrypto.a zlib_mingw/libz.a $(LDFLAGS)


### PR DESCRIPTION
This PR adds 64-bit Windows builds to Travis so that any breaks are noticed right away.  Once 32-bit builds are fixed, Travis can be updated to make 32-bit builds as well.

FYI, I removed the "env" and "compiler" sections to simplify the config overall; otherwise, a complex exclude matrix would have been needed to handle un-needed tests.