### PR TITLE
Allow to override prefix in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ endif
 OS := $(shell uname)
 
 SRCS      = sslscan.c
-PREFIX    = /usr
+PREFIX    ?= /usr
 BINDIR    = $(PREFIX)/bin
 MANDIR    = $(PREFIX)/share/man
 MAN1DIR   = $(MANDIR)/man1


### PR DESCRIPTION
Hello,

I am one of the maintainers of the sslscan package in [Termux](https://termux.com/).
Termux uses a custom prefix so we had to patch your Makefile.

This PR allows the build process to overrif the `PREFIX` variable without having to patch the Makefile.