### PR TITLE
Fix gcc check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 # set gcc as default if CC is not set
-ifndef $(CC)
-  CC=gcc
-endif
+CC?=gcc
 
 GIT_VERSION = $(shell git describe --tags --always --dirty=-wip)
 


### PR DESCRIPTION
The condition at the beginning of your Makefile does not work correctly because it need to be written like this:
```Makefile
ifndef CC
```

This PR uses the short form which IMHO is less confusing.

Edit: I see this was modified in order to make it work on Solaris: 06e8c94fcc62dcec354f53d5e30a0a9077e343de
Could it be that Solaris and Linux use slightly different syntaxes?