### PR TITLE
Fix hardening switches on FreeBSD clang 3.4.1+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ ifneq ($(OS), Darwin)
 ifneq ($(OS), SunOS)
 # Cygwin's linker does not support -z option.
 ifneq ($(findstring CYGWIN,$(OS)),CYGWIN)
-	LDFLAGS += -pie -z relro -z now
+	LDFLAGS += -pie -Wl,-z,relro -Wl,-z,now
 endif
 endif
 endif


### PR DESCRIPTION
clang does not know about `-z`. Pass rather with `-Wl`. Works for me on:

`cc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-23) ` and `FreeBSD clang version 3.4.1 (tags/RELEASE_34/dot1-final 208032) 20140512`.