### PR TITLE
 RFC: Additional SSL error reporting in verbose mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ required to compile OpenSSL from source on OS X. Once you have, just run:
 
 ### OpenSSL issues
 
-#### OpenSSL 1.1.0 Support
+#### OpenSSL 1.1.0 and later
 OpenSSL 1.1.0 introduced a number of significant changes, including the removal
 of old and insecure features such as SSLv2. While this is a very good thing for
 the SSL ecosystem as a whole, it is a problem for sslscan, which relies on

--- a/sslscan.c
+++ b/sslscan.c
@@ -1574,8 +1574,8 @@ int testCipher(struct sslCheckOptions *options, const SSL_METHOD *sslMethod)
                 }
                 else if (cipherStatus != 1)
                 {
-                    SSL_free(ssl);
                     printf_verbose("SSL_get_error(ssl, cipherStatus) said: %d\n", SSL_get_error(ssl, cipherStatus));
+                    SSL_free(ssl);
                     return false;
                 }
 


### PR DESCRIPTION
Add a function to convert SSL error codes to a string.
In addition, get the underlying error from OpenSSL and display it (when in verbose mode).

Before:
[...]
Accepted  TLSv1.0  128 bits  AES128-SHA
SSL_get_error(ssl, cipherStatus) said: 1

After:
[...]
Accepted  TLSv1.0  128 bits  AES128-SHA
SSL_get_error(ssl, cipherStatus) returned: 1 (SSL_ERROR_SSL)
[sslscan.c:testCipher@1584]:error:1408F10B:SSL routines:SSL3_GET_RECORD:wrong version number