### PR TITLE
Fixed docker tests

### DIFF
--- a/docker_test/expected_output/test_1.txt
+++ b/docker_test/expected_output/test_1.txt
@@ -4,12 +4,12 @@
 Testing SSL server [32m127.0.0.1[0m on port [32m4443[0m using SNI name [32m127.0.0.1[0m
 
   [1;34mSSL/TLS Protocols:[0m
-SSLv2 is [32mnot enabled[0m
-SSLv3 is [31menabled[0m
-TLSv1.0 is [33menabled[0m
-TLSv1.1 is enabled
-TLSv1.2 is enabled
-TLSv1.3 is not enabled
+SSLv2     [32mdisabled[0m
+SSLv3     [31menabled[0m
+TLSv1.0   [33menabled[0m
+TLSv1.1   enabled
+TLSv1.2   enabled
+TLSv1.3   not enabled
 
   [1;34mTLS Fallback SCSV:[0m
 Server [32msupports[0m TLS Fallback SCSV
@@ -21,9 +21,9 @@ Server [32msupports[0m TLS Fallback SCSV
 Compression [31menabled[0m (CRIME)
 
   [1;34mHeartbleed:[0m
-TLS 1.2 [32mnot vulnerable[0m to heartbleed
-TLS 1.1 [32mnot vulnerable[0m to heartbleed
-TLS 1.0 [32mnot vulnerable[0m to heartbleed
+TLSv1.2 [32mnot vulnerable[0m to heartbleed
+TLSv1.1 [32mnot vulnerable[0m to heartbleed
+TLSv1.0 [32mnot vulnerable[0m to heartbleed
 
   [1;34mSupported Server Cipher(s):[0m
 [32mPreferred[0m TLSv1.2  [32m256[0m bits  [32mECDHE-RSA-AES256-GCM-SHA384  [0m Curve P-256 DHE 256

--- a/docker_test/expected_output/test_10.txt
+++ b/docker_test/expected_output/test_10.txt
@@ -4,12 +4,12 @@
 Testing SSL server [32m127.0.0.1[0m on port [32m4443[0m using SNI name [32m127.0.0.1[0m
 
   [1;34mSSL/TLS Protocols:[0m
-SSLv2 is [32mnot enabled[0m
-SSLv3 is [32mnot enabled[0m
-TLSv1.0 is [32mnot enabled[0m
-TLSv1.1 is not enabled
-TLSv1.2 is enabled
-TLSv1.3 is not enabled
+SSLv2     [32mdisabled[0m
+SSLv3     [32mdisabled[0m
+TLSv1.0   [32mdisabled[0m
+TLSv1.1   disabled
+TLSv1.2   enabled
+TLSv1.3   not enabled
 
   [1;34mSupported Server Cipher(s):[0m
 [32mPreferred[0m 400 Bad Request  TLSv1.2  [32m256[0m bits  [32mECDHE-RSA-CHACHA20-POLY1305  [0m Curve [32m25519[0m DHE 253

--- a/docker_test/expected_output/test_11.txt
+++ b/docker_test/expected_output/test_11.txt
@@ -4,12 +4,12 @@
 Testing SSL server [32mwww.amazon.com[0m on port [32m443[0m using SNI name [32mwww.amazon.com[0m
 
   [1;34mSSL/TLS Protocols:[0m
-SSLv2 is [32mnot enabled[0m
-SSLv3 is [32mnot enabled[0m
-TLSv1.0 is [33menabled[0m
-TLSv1.1 is enabled
-TLSv1.2 is enabled
-TLSv1.3 is not enabled
+SSLv2     [32mdisabled[0m
+SSLv3     [32mdisabled[0m
+TLSv1.0   [33menabled[0m
+TLSv1.1   enabled
+TLSv1.2   enabled
+TLSv1.3   not enabled
 
   [1;34mOCSP Stapling Request:[0m
 OCSP Response Status: successful (0x0)

--- a/docker_test/expected_output/test_12.txt
+++ b/docker_test/expected_output/test_12.txt
@@ -4,12 +4,12 @@
 Testing SSL server [32m127.0.0.1[0m on port [32m4443[0m using SNI name [32m127.0.0.1[0m
 
   [1;34mSSL/TLS Protocols:[0m
-SSLv2 is [31menabled[0m
-SSLv3 is [31menabled[0m
-TLSv1.0 is [33menabled[0m
-TLSv1.1 is not enabled
-TLSv1.2 is not enabled
-TLSv1.3 is not enabled
+SSLv2     [31menabled[0m
+SSLv3     [31menabled[0m
+TLSv1.0   [33menabled[0m
+TLSv1.1   disabled
+TLSv1.2   disabled
+TLSv1.3   not enabled
 
   [1;34mTLS Fallback SCSV:[0m
 Server [31mdoes not[0m support TLS Fallback SCSV
@@ -21,7 +21,7 @@ Server [31mdoes not[0m support TLS Fallback SCSV
 Compression [31menabled[0m (CRIME)
 
   [1;34mHeartbleed:[0m
-TLS 1.0 [32mnot vulnerable[0m to heartbleed
+TLSv1.0 [32mnot vulnerable[0m to heartbleed
 
   [1;34mSupported Server Cipher(s):[0m
 [32mPreferred[0m [33mTLSv1.0[0m  [32m256[0m bits  ECDHE-RSA-AES256-SHA          Curve P-256 DHE 256

--- a/docker_test/expected_output/test_13.txt
+++ b/docker_test/expected_output/test_13.txt
@@ -4,12 +4,12 @@
 Testing SSL server [32m127.0.0.1[0m on port [32m4443[0m using SNI name [32m127.0.0.1[0m
 
   [1;34mSSL/TLS Protocols:[0m
-SSLv2 is [32mnot enabled[0m
-SSLv3 is [32mnot enabled[0m
-TLSv1.0 is [33menabled[0m
-TLSv1.1 is enabled
-TLSv1.2 is enabled
-TLSv1.3 is enabled
+SSLv2     [32mdisabled[0m
+SSLv3     [32mdisabled[0m
+TLSv1.0   [33menabled[0m
+TLSv1.1   enabled
+TLSv1.2   enabled
+TLSv1.3   [32menabled[0m
 
   [1;34mTLS Fallback SCSV:[0m
 Server [32msupports[0m TLS Fallback SCSV
@@ -21,16 +21,16 @@ Server [32msupports[0m TLS Fallback SCSV
 Compression [32mdisabled[0m
 
   [1;34mHeartbleed:[0m
-TLS 1.3 [32mnot vulnerable[0m to heartbleed
-TLS 1.2 [32mnot vulnerable[0m to heartbleed
-TLS 1.1 [32mnot vulnerable[0m to heartbleed
-TLS 1.0 [32mnot vulnerable[0m to heartbleed
+TLSv1.3 [32mnot vulnerable[0m to heartbleed
+TLSv1.2 [32mnot vulnerable[0m to heartbleed
+TLSv1.1 [32mnot vulnerable[0m to heartbleed
+TLSv1.0 [32mnot vulnerable[0m to heartbleed
 
   [1;34mSupported Server Cipher(s):[0m
-[32mPreferred[0m TLSv1.3  [32m128[0m bits  TLS_AES_128_GCM_SHA256        Curve [32m25519[0m DHE 253
-Accepted  TLSv1.3  [32m256[0m bits  TLS_AES_256_GCM_SHA384        Curve [32m25519[0m DHE 253
-Accepted  TLSv1.3  [32m256[0m bits  TLS_CHACHA20_POLY1305_SHA256  Curve [32m25519[0m DHE 253
-Accepted  TLSv1.3  [32m128[0m bits  TLS_AES_128_CCM_SHA256        Curve [32m25519[0m DHE 253
+[32mPreferred[0m [32mTLSv1.3[0m  [32m128[0m bits  TLS_AES_128_GCM_SHA256        Curve [32m25519[0m DHE 253
+Accepted  [32mTLSv1.3[0m  [32m256[0m bits  TLS_AES_256_GCM_SHA384        Curve [32m25519[0m DHE 253
+Accepted  [32mTLSv1.3[0m  [32m256[0m bits  TLS_CHACHA20_POLY1305_SHA256  Curve [32m25519[0m DHE 253
+Accepted  [32mTLSv1.3[0m  [32m128[0m bits  TLS_AES_128_CCM_SHA256        Curve [32m25519[0m DHE 253
 [32mPreferred[0m TLSv1.2  [32m256[0m bits  [32mECDHE-RSA-AES256-GCM-SHA384  [0m Curve [32m25519[0m DHE 253
 Accepted  TLSv1.2  [32m256[0m bits  [32mDHE-RSA-AES256-GCM-SHA384    [0m DHE 2048 bits
 Accepted  TLSv1.2  [32m256[0m bits  [32mECDHE-RSA-CHACHA20-POLY1305  [0m Curve [32m25519[0m DHE 253

--- a/docker_test/expected_output/test_14.txt
+++ b/docker_test/expected_output/test_14.txt
@@ -4,12 +4,12 @@
 Testing SSL server [32m127.0.0.1[0m on port [32m4443[0m using SNI name [32m127.0.0.1[0m
 
   [1;34mSSL/TLS Protocols:[0m
-SSLv2 is [32mnot enabled[0m
-SSLv3 is [32mnot enabled[0m
-TLSv1.0 is [32mnot enabled[0m
-TLSv1.1 is not enabled
-TLSv1.2 is enabled
-TLSv1.3 is enabled
+SSLv2     [32mdisabled[0m
+SSLv3     [32mdisabled[0m
+TLSv1.0   [32mdisabled[0m
+TLSv1.1   disabled
+TLSv1.2   enabled
+TLSv1.3   [32menabled[0m
 
   [1;34mTLS Fallback SCSV:[0m
 Server [32msupports[0m TLS Fallback SCSV
@@ -21,14 +21,14 @@ Session renegotiation [32mnot supported[0m
 Compression [32mdisabled[0m
 
   [1;34mHeartbleed:[0m
-TLS 1.3 [32mnot vulnerable[0m to heartbleed
-TLS 1.2 [32mnot vulnerable[0m to heartbleed
+TLSv1.3 [32mnot vulnerable[0m to heartbleed
+TLSv1.2 [32mnot vulnerable[0m to heartbleed
 
   [1;34mSupported Server Cipher(s):[0m
-[32mPreferred[0m TLSv1.3  [32m128[0m bits  TLS_AES_128_GCM_SHA256        Curve P-521 DHE 521
-Accepted  TLSv1.3  [32m256[0m bits  TLS_AES_256_GCM_SHA384        Curve P-521 DHE 521
-Accepted  TLSv1.3  [32m256[0m bits  TLS_CHACHA20_POLY1305_SHA256  Curve P-521 DHE 521
-Accepted  TLSv1.3  [32m128[0m bits  TLS_AES_128_CCM_SHA256        Curve P-521 DHE 521
+[32mPreferred[0m [32mTLSv1.3[0m  [32m128[0m bits  TLS_AES_128_GCM_SHA256        Curve P-521 DHE 521
+Accepted  [32mTLSv1.3[0m  [32m256[0m bits  TLS_AES_256_GCM_SHA384        Curve P-521 DHE 521
+Accepted  [32mTLSv1.3[0m  [32m256[0m bits  TLS_CHACHA20_POLY1305_SHA256  Curve P-521 DHE 521
+Accepted  [32mTLSv1.3[0m  [32m128[0m bits  TLS_AES_128_CCM_SHA256        Curve P-521 DHE 521
 [32mPreferred[0m TLSv1.2  [32m256[0m bits  [32mECDHE-RSA-AES256-GCM-SHA384  [0m Curve P-521 DHE 521
 Accepted  TLSv1.2  [32m256[0m bits  [32mDHE-RSA-AES256-GCM-SHA384    [0m DHE 8192 bits
 Accepted  TLSv1.2  [32m256[0m bits  [32mECDHE-RSA-CHACHA20-POLY1305  [0m Curve P-521 DHE 521

--- a/docker_test/expected_output/test_15.txt
+++ b/docker_test/expected_output/test_15.txt
@@ -4,12 +4,12 @@
 Testing SSL server [32m127.0.0.1[0m on port [32m4443[0m using SNI name [32m127.0.0.1[0m
 
   [1;34mSSL/TLS Protocols:[0m
-SSLv2 is [32mnot enabled[0m
-SSLv3 is [32mnot enabled[0m
-TLSv1.0 is [33menabled[0m
-TLSv1.1 is enabled
-TLSv1.2 is enabled
-TLSv1.3 is enabled
+SSLv2     [32mdisabled[0m
+SSLv3     [32mdisabled[0m
+TLSv1.0   [33menabled[0m
+TLSv1.1   enabled
+TLSv1.2   enabled
+TLSv1.3   [32menabled[0m
 
   [1;34mTLS Fallback SCSV:[0m
 Server [32msupports[0m TLS Fallback SCSV
@@ -21,16 +21,16 @@ Server [32msupports[0m TLS Fallback SCSV
 Compression [32mdisabled[0m
 
   [1;34mHeartbleed:[0m
-TLS 1.3 [32mnot vulnerable[0m to heartbleed
-TLS 1.2 [32mnot vulnerable[0m to heartbleed
-TLS 1.1 [32mnot vulnerable[0m to heartbleed
-TLS 1.0 [32mnot vulnerable[0m to heartbleed
+TLSv1.3 [32mnot vulnerable[0m to heartbleed
+TLSv1.2 [32mnot vulnerable[0m to heartbleed
+TLSv1.1 [32mnot vulnerable[0m to heartbleed
+TLSv1.0 [32mnot vulnerable[0m to heartbleed
 
   [1;34mSupported Server Cipher(s):[0m
-[32mPreferred[0m TLSv1.3  [32m128[0m bits  TLS_AES_128_GCM_SHA256        Curve [32m25519[0m DHE 253
-Accepted  TLSv1.3  [32m256[0m bits  TLS_AES_256_GCM_SHA384        Curve [32m25519[0m DHE 253
-Accepted  TLSv1.3  [32m256[0m bits  TLS_CHACHA20_POLY1305_SHA256  Curve [32m25519[0m DHE 253
-Accepted  TLSv1.3  [32m128[0m bits  TLS_AES_128_CCM_SHA256        Curve [32m25519[0m DHE 253
+[32mPreferred[0m [32mTLSv1.3[0m  [32m128[0m bits  TLS_AES_128_GCM_SHA256        Curve [32m25519[0m DHE 253
+Accepted  [32mTLSv1.3[0m  [32m256[0m bits  TLS_AES_256_GCM_SHA384        Curve [32m25519[0m DHE 253
+Accepted  [32mTLSv1.3[0m  [32m256[0m bits  TLS_CHACHA20_POLY1305_SHA256  Curve [32m25519[0m DHE 253
+Accepted  [32mTLSv1.3[0m  [32m128[0m bits  TLS_AES_128_CCM_SHA256        Curve [32m25519[0m DHE 253
 [32mPreferred[0m TLSv1.2  [32m256[0m bits  [32mECDHE-ECDSA-AES256-GCM-SHA384[0m Curve [32m25519[0m DHE 253
 Accepted  TLSv1.2  [32m256[0m bits  [32mECDHE-ECDSA-CHACHA20-POLY1305[0m Curve [32m25519[0m DHE 253
 Accepted  TLSv1.2  [32m256[0m bits  ECDHE-ECDSA-AES256-CCM        Curve [32m25519[0m DHE 253

--- a/docker_test/expected_output/test_16.txt
+++ b/docker_test/expected_output/test_16.txt
@@ -4,12 +4,12 @@
 Testing SSL server [32m127.0.0.1[0m on port [32m4443[0m using SNI name [32m127.0.0.1[0m
 
   [1;34mSSL/TLS Protocols:[0m
-SSLv2 is [32mnot enabled[0m
-SSLv3 is [32mnot enabled[0m
-TLSv1.0 is [32mnot enabled[0m
-TLSv1.1 is not enabled
-TLSv1.2 is enabled
-TLSv1.3 is not enabled
+SSLv2     [32mdisabled[0m
+SSLv3     [32mdisabled[0m
+TLSv1.0   [32mdisabled[0m
+TLSv1.1   disabled
+TLSv1.2   enabled
+TLSv1.3   not enabled
 
   [1;34mTLS Fallback SCSV:[0m
 Server [32msupports[0m TLS Fallback SCSV
@@ -21,7 +21,7 @@ Session renegotiation [32mnot supported[0m
 Compression [32mdisabled[0m
 
   [1;34mHeartbleed:[0m
-TLS 1.2 [32mnot vulnerable[0m to heartbleed
+TLSv1.2 [32mnot vulnerable[0m to heartbleed
 
   [1;34mSupported Server Cipher(s):[0m
 [32mPreferred[0m TLSv1.2  [32m256[0m bits  [32mDHE-RSA-AES256-GCM-SHA384    [0m DHE 2048 bits

--- a/docker_test/expected_output/test_17.txt
+++ b/docker_test/expected_output/test_17.txt
@@ -4,12 +4,12 @@
 Testing SSL server [32m127.0.0.1[0m on port [32m4443[0m using SNI name [32m127.0.0.1[0m
 
   [1;34mSSL/TLS Protocols:[0m
-SSLv2 is [32mnot enabled[0m
-SSLv3 is [32mnot enabled[0m
-TLSv1.0 is [32mnot enabled[0m
-TLSv1.1 is not enabled
-TLSv1.2 is enabled
-TLSv1.3 is not enabled
+SSLv2     [32mdisabled[0m
+SSLv3     [32mdisabled[0m
+TLSv1.0   [32mdisabled[0m
+TLSv1.1   disabled
+TLSv1.2   enabled
+TLSv1.3   not enabled
 
   [1;34mTLS Fallback SCSV:[0m
 Server [32msupports[0m TLS Fallback SCSV
@@ -21,7 +21,7 @@ Session renegotiation [32mnot supported[0m
 Compression [32mdisabled[0m
 
   [1;34mHeartbleed:[0m
-TLS 1.2 [32mnot vulnerable[0m to heartbleed
+TLSv1.2 [32mnot vulnerable[0m to heartbleed
 
   [1;34mSupported Server Cipher(s):[0m
 [32mPreferred[0m TLSv1.2  [32m256[0m bits  [32mDHE-RSA-AES256-GCM-SHA384    [0m DHE [33m1024[0m bits

--- a/docker_test/expected_output/test_18.txt
+++ b/docker_test/expected_output/test_18.txt
@@ -4,12 +4,12 @@
 Testing SSL server [32m127.0.0.1[0m on port [32m4443[0m using SNI name [32m127.0.0.1[0m
 
   [1;34mSSL/TLS Protocols:[0m
-SSLv2 is [32mnot enabled[0m
-SSLv3 is [32mnot enabled[0m
-TLSv1.0 is [32mnot enabled[0m
-TLSv1.1 is not enabled
-TLSv1.2 is enabled
-TLSv1.3 is not enabled
+SSLv2     [32mdisabled[0m
+SSLv3     [32mdisabled[0m
+TLSv1.0   [32mdisabled[0m
+TLSv1.1   disabled
+TLSv1.2   enabled
+TLSv1.3   not enabled
 
   [1;34mTLS Fallback SCSV:[0m
 Server [32msupports[0m TLS Fallback SCSV
@@ -21,7 +21,7 @@ Session renegotiation [32mnot supported[0m
 Compression [32mdisabled[0m
 
   [1;34mHeartbleed:[0m
-TLS 1.2 [32mnot vulnerable[0m to heartbleed
+TLSv1.2 [32mnot vulnerable[0m to heartbleed
 
   [1;34mSupported Server Cipher(s):[0m
 [32mPreferred[0m TLSv1.2  [32m256[0m bits  [32mECDHE-ECDSA-CHACHA20-POLY1305[0m Curve [32m25519[0m DHE 253

--- a/docker_test/expected_output/test_2.txt
+++ b/docker_test/expected_output/test_2.txt
@@ -4,12 +4,12 @@
 Testing SSL server [32m127.0.0.1[0m on port [32m4443[0m using SNI name [32m127.0.0.1[0m
 
   [1;34mSSL/TLS Protocols:[0m
-SSLv2 is [31menabled[0m
-SSLv3 is [32mnot enabled[0m
-TLSv1.0 is [32mnot enabled[0m
-TLSv1.1 is not enabled
-TLSv1.2 is not enabled
-TLSv1.3 is not enabled
+SSLv2     [31menabled[0m
+SSLv3     [32mdisabled[0m
+TLSv1.0   [32mdisabled[0m
+TLSv1.1   disabled
+TLSv1.2   disabled
+TLSv1.3   not enabled
 
   [1;34mTLS Fallback SCSV:[0m
 [33mConnection failed[0m - unable to determine TLS Fallback SCSV support

--- a/docker_test/expected_output/test_3.txt
+++ b/docker_test/expected_output/test_3.txt
@@ -4,12 +4,12 @@
 Testing SSL server [32m127.0.0.1[0m on port [32m4443[0m using SNI name [32m127.0.0.1[0m
 
   [1;34mSSL/TLS Protocols:[0m
-SSLv2 is [32mnot enabled[0m
-SSLv3 is [31menabled[0m
-TLSv1.0 is [32mnot enabled[0m
-TLSv1.1 is not enabled
-TLSv1.2 is not enabled
-TLSv1.3 is not enabled
+SSLv2     [32mdisabled[0m
+SSLv3     [31menabled[0m
+TLSv1.0   [32mdisabled[0m
+TLSv1.1   disabled
+TLSv1.2   disabled
+TLSv1.3   not enabled
 
   [1;34mTLS Fallback SCSV:[0m
 [33mConnection failed[0m - unable to determine TLS Fallback SCSV support

--- a/docker_test/expected_output/test_4.txt
+++ b/docker_test/expected_output/test_4.txt
@@ -4,12 +4,12 @@
 Testing SSL server [32m127.0.0.1[0m on port [32m4443[0m using SNI name [32m127.0.0.1[0m
 
   [1;34mSSL/TLS Protocols:[0m
-SSLv2 is [32mnot enabled[0m
-SSLv3 is [32mnot enabled[0m
-TLSv1.0 is [33menabled[0m
-TLSv1.1 is enabled
-TLSv1.2 is enabled
-TLSv1.3 is enabled
+SSLv2     [32mdisabled[0m
+SSLv3     [32mdisabled[0m
+TLSv1.0   [33menabled[0m
+TLSv1.1   enabled
+TLSv1.2   enabled
+TLSv1.3   [32menabled[0m
 
   [1;34mTLS Fallback SCSV:[0m
 Server [32msupports[0m TLS Fallback SCSV
@@ -21,15 +21,15 @@ Server [32msupports[0m TLS Fallback SCSV
 Compression [32mdisabled[0m
 
   [1;34mHeartbleed:[0m
-TLS 1.3 [32mnot vulnerable[0m to heartbleed
-TLS 1.2 [32mnot vulnerable[0m to heartbleed
-TLS 1.1 [32mnot vulnerable[0m to heartbleed
-TLS 1.0 [32mnot vulnerable[0m to heartbleed
+TLSv1.3 [32mnot vulnerable[0m to heartbleed
+TLSv1.2 [32mnot vulnerable[0m to heartbleed
+TLSv1.1 [32mnot vulnerable[0m to heartbleed
+TLSv1.0 [32mnot vulnerable[0m to heartbleed
 
   [1;34mSupported Server Cipher(s):[0m
-[32mPreferred[0m TLSv1.3  [32m128[0m bits  TLS_AES_128_GCM_SHA256        Curve [32m25519[0m DHE 253
-Accepted  TLSv1.3  [32m256[0m bits  TLS_AES_256_GCM_SHA384        Curve [32m25519[0m DHE 253
-Accepted  TLSv1.3  [32m256[0m bits  TLS_CHACHA20_POLY1305_SHA256  Curve [32m25519[0m DHE 253
+[32mPreferred[0m [32mTLSv1.3[0m  [32m128[0m bits  TLS_AES_128_GCM_SHA256        Curve [32m25519[0m DHE 253
+Accepted  [32mTLSv1.3[0m  [32m256[0m bits  TLS_AES_256_GCM_SHA384        Curve [32m25519[0m DHE 253
+Accepted  [32mTLSv1.3[0m  [32m256[0m bits  TLS_CHACHA20_POLY1305_SHA256  Curve [32m25519[0m DHE 253
 [32mPreferred[0m TLSv1.2  [32m256[0m bits  [32mECDHE-RSA-AES256-GCM-SHA384  [0m Curve [32m25519[0m DHE 253
 Accepted  TLSv1.2  [32m256[0m bits  [32mDHE-RSA-AES256-GCM-SHA384    [0m DHE 3072 bits
 Accepted  TLSv1.2  [32m256[0m bits  [32mECDHE-RSA-CHACHA20-POLY1305  [0m Curve [32m25519[0m DHE 253

--- a/docker_test/expected_output/test_5.txt
+++ b/docker_test/expected_output/test_5.txt
@@ -4,12 +4,12 @@
 Testing SSL server [32m127.0.0.1[0m on port [32m4443[0m using SNI name [32m127.0.0.1[0m
 
   [1;34mSSL/TLS Protocols:[0m
-SSLv2 is [32mnot enabled[0m
-SSLv3 is [31menabled[0m
-TLSv1.0 is [33menabled[0m
-TLSv1.1 is enabled
-TLSv1.2 is enabled
-TLSv1.3 is not enabled
+SSLv2     [32mdisabled[0m
+SSLv3     [31menabled[0m
+TLSv1.0   [33menabled[0m
+TLSv1.1   enabled
+TLSv1.2   enabled
+TLSv1.3   not enabled
 
   [1;34mTLS Fallback SCSV:[0m
 Server [32msupports[0m TLS Fallback SCSV
@@ -21,9 +21,9 @@ Server [32msupports[0m TLS Fallback SCSV
 Compression [31menabled[0m (CRIME)
 
   [1;34mHeartbleed:[0m
-TLS 1.2 [32mnot vulnerable[0m to heartbleed
-TLS 1.1 [32mnot vulnerable[0m to heartbleed
-TLS 1.0 [32mnot vulnerable[0m to heartbleed
+TLSv1.2 [32mnot vulnerable[0m to heartbleed
+TLSv1.1 [32mnot vulnerable[0m to heartbleed
+TLSv1.0 [32mnot vulnerable[0m to heartbleed
 
   [1;34mSupported Server Cipher(s):[0m
 [32mPreferred[0m TLSv1.2  [32m256[0m bits  [32mECDHE-RSA-AES256-GCM-SHA384  [0m Curve P-256 DHE 256

--- a/docker_test/expected_output/test_6.txt
+++ b/docker_test/expected_output/test_6.txt
@@ -4,12 +4,12 @@
 Testing SSL server [32m127.0.0.1[0m on port [32m4443[0m using SNI name [32m127.0.0.1[0m
 
   [1;34mSSL/TLS Protocols:[0m
-SSLv2 is [32mnot enabled[0m
-SSLv3 is [32mnot enabled[0m
-TLSv1.0 is [32mnot enabled[0m
-TLSv1.1 is not enabled
-TLSv1.2 is not enabled
-TLSv1.3 is enabled
+SSLv2     [32mdisabled[0m
+SSLv3     [32mdisabled[0m
+TLSv1.0   [32mdisabled[0m
+TLSv1.1   disabled
+TLSv1.2   disabled
+TLSv1.3   [32menabled[0m
 
   [1;34mTLS Fallback SCSV:[0m
 Server [32msupports[0m TLS Fallback SCSV
@@ -21,14 +21,14 @@ Session renegotiation [32mnot supported[0m
 Compression [32mdisabled[0m
 
   [1;34mHeartbleed:[0m
-TLS 1.3 [32mnot vulnerable[0m to heartbleed
+TLSv1.3 [32mnot vulnerable[0m to heartbleed
 
   [1;34mSupported Server Cipher(s):[0m
-[32mPreferred[0m TLSv1.3  [32m128[0m bits  TLS_AES_128_GCM_SHA256        Curve [32m25519[0m DHE 253
-Accepted  TLSv1.3  [32m256[0m bits  TLS_AES_256_GCM_SHA384        Curve [32m25519[0m DHE 253
-Accepted  TLSv1.3  [32m256[0m bits  TLS_CHACHA20_POLY1305_SHA256  Curve [32m25519[0m DHE 253
-Accepted  TLSv1.3  [32m128[0m bits  TLS_AES_128_CCM_SHA256        Curve [32m25519[0m DHE 253
-Accepted  TLSv1.3  [32m128[0m bits  TLS_AES_128_CCM_8_SHA256      Curve [32m25519[0m DHE 253
+[32mPreferred[0m [32mTLSv1.3[0m  [32m128[0m bits  TLS_AES_128_GCM_SHA256        Curve [32m25519[0m DHE 253
+Accepted  [32mTLSv1.3[0m  [32m256[0m bits  TLS_AES_256_GCM_SHA384        Curve [32m25519[0m DHE 253
+Accepted  [32mTLSv1.3[0m  [32m256[0m bits  TLS_CHACHA20_POLY1305_SHA256  Curve [32m25519[0m DHE 253
+Accepted  [32mTLSv1.3[0m  [32m128[0m bits  TLS_AES_128_CCM_SHA256        Curve [32m25519[0m DHE 253
+Accepted  [32mTLSv1.3[0m  [32m128[0m bits  TLS_AES_128_CCM_8_SHA256      Curve [32m25519[0m DHE 253
 
   [1;34mServer Key Exchange Group(s):[0m
 TLSv1.3  [32m128[0m bits  secp256r1 (NIST P-256)[0m

--- a/docker_test/expected_output/test_7.txt
+++ b/docker_test/expected_output/test_7.txt
@@ -4,12 +4,12 @@
 Testing SSL server [32m127.0.0.1[0m on port [32m4443[0m using SNI name [32m127.0.0.1[0m
 
   [1;34mSSL/TLS Protocols:[0m
-SSLv2 is [31menabled[0m
-SSLv3 is [31menabled[0m
-TLSv1.0 is [33menabled[0m
-TLSv1.1 is not enabled
-TLSv1.2 is not enabled
-TLSv1.3 is not enabled
+SSLv2     [31menabled[0m
+SSLv3     [31menabled[0m
+TLSv1.0   [33menabled[0m
+TLSv1.1   disabled
+TLSv1.2   disabled
+TLSv1.3   not enabled
 
   [1;34mTLS Fallback SCSV:[0m
 Server [31mdoes not[0m support TLS Fallback SCSV
@@ -21,7 +21,7 @@ Server [31mdoes not[0m support TLS Fallback SCSV
 Compression [31menabled[0m (CRIME)
 
   [1;34mHeartbleed:[0m
-TLS 1.0 [32mnot vulnerable[0m to heartbleed
+TLSv1.0 [32mnot vulnerable[0m to heartbleed
 
   [1;34mSupported Server Cipher(s):[0m
 [32mPreferred[0m [33mTLSv1.0[0m  [32m256[0m bits  ECDHE-RSA-AES256-SHA          Curve P-256 DHE 256

--- a/docker_test/expected_output/test_8.txt
+++ b/docker_test/expected_output/test_8.txt
@@ -4,12 +4,12 @@
 Testing SSL server [32m127.0.0.1[0m on port [32m4443[0m using SNI name [32m127.0.0.1[0m
 
   [1;34mSSL/TLS Protocols:[0m
-SSLv2 is [31menabled[0m
-SSLv3 is [31menabled[0m
-TLSv1.0 is [33menabled[0m
-TLSv1.1 is not enabled
-TLSv1.2 is not enabled
-TLSv1.3 is not enabled
+SSLv2     [31menabled[0m
+SSLv3     [31menabled[0m
+TLSv1.0   [33menabled[0m
+TLSv1.1   disabled
+TLSv1.2   disabled
+TLSv1.3   not enabled
 
   [1;34mTLS Fallback SCSV:[0m
 Server [31mdoes not[0m support TLS Fallback SCSV
@@ -21,7 +21,7 @@ Server [31mdoes not[0m support TLS Fallback SCSV
 Compression [31menabled[0m (CRIME)
 
   [1;34mHeartbleed:[0m
-TLS 1.0 [32mnot vulnerable[0m to heartbleed
+TLSv1.0 [32mnot vulnerable[0m to heartbleed
 
   [1;34mSupported Server Cipher(s):[0m
 [32mPreferred[0m [33mTLSv1.0[0m  [32m256[0m bits  ECDHE-RSA-AES256-SHA          Curve P-256 DHE 256

--- a/docker_test/expected_output/test_9.txt
+++ b/docker_test/expected_output/test_9.txt
@@ -4,12 +4,12 @@
 Testing SSL server [32m127.0.0.1[0m on port [32m4443[0m using SNI name [32m127.0.0.1[0m
 
   [1;34mSSL/TLS Protocols:[0m
-SSLv2 is [32mnot enabled[0m
-SSLv3 is [32mnot enabled[0m
-TLSv1.0 is [32mnot enabled[0m
-TLSv1.1 is not enabled
-TLSv1.2 is enabled
-TLSv1.3 is not enabled
+SSLv2     [32mdisabled[0m
+SSLv3     [32mdisabled[0m
+TLSv1.0   [32mdisabled[0m
+TLSv1.1   disabled
+TLSv1.2   enabled
+TLSv1.3   not enabled
 
   [1;34mSupported Server Cipher(s):[0m
 [32mPreferred[0m 200 OK           TLSv1.2  [32m256[0m bits  [32mECDHE-RSA-CHACHA20-POLY1305  [0m Curve [32m25519[0m DHE 253


### PR DESCRIPTION
The docker tests were broken because changes to the output were made (i.e.: "not enabled" -> "disabled", etc).