### PR TITLE
Allow trailing slash ('/') in URLs with no port specified

### DIFF
--- a/sslscan.c
+++ b/sslscan.c
@@ -3948,7 +3948,7 @@ int main(int argc, char *argv[])
             }
 
             while ((hostString[tempInt] != 0) && ((squareBrackets == true && hostString[tempInt] != ']')
-                        || (squareBrackets == false && hostString[tempInt] != ':')))
+                        || (squareBrackets == false && hostString[tempInt] != ':' && hostString[tempInt] != '/')))
             {
                 tempInt++;
             }
@@ -3956,7 +3956,7 @@ int main(int argc, char *argv[])
             if (squareBrackets == true && hostString[tempInt] == ']')
             {
                 hostString[tempInt] = 0;
-                if (tempInt < maxSize && hostString[tempInt + 1] == ':')
+                if (tempInt < maxSize && (hostString[tempInt + 1] == ':' || hostString[tempInt + 1] == '/'))
                 {
                     tempInt++;
                     hostString[tempInt] = 0;


### PR DESCRIPTION
Using a URL with a trailing slash, and not specifying a port, results in the slash being added to the host string and causing a resolution failure (as shown [here](https://imgur.com/HBlFrHF)).
The fix is adding checks to truncate the trailing slash in the same way a colon would be during port specification.

However, the way this handles `/` and `:` interchangeably at the end means that the URL `https://example.org/4443/` is parsed the same as `https://example.org:4443/`.

I can add extra handling if this is unacceptable.