### PR TITLE
Now prints the curve name and key strength for ECC certificates.

### DIFF
--- a/docker_test/expected_output/test_15.txt
+++ b/docker_test/expected_output/test_15.txt
@@ -67,6 +67,9 @@ TLSv1.2  ecdsa_secp521r1_sha512[0m
 
   [1;34mSSL Certificate:[0m
 Signature Algorithm: [32msha256WithRSAEncryption[0m
+ECC Curve Name:      prime256v1
+ECC Key Strength:    128[0m
+
 Subject:  itspeanutbutterjellytime.com
 Issuer:   /C=XX/ST=Nowhere in particular/L=Nowhere
 Not valid before: [32mDec 22 19:01:56 2019 GMT[0m

--- a/docker_test/expected_output/test_18.txt
+++ b/docker_test/expected_output/test_18.txt
@@ -39,6 +39,9 @@ TLSv1.2  [31mecdsa_sha1[0m
 
   [1;34mSSL Certificate:[0m
 Signature Algorithm: [32msha256WithRSAEncryption[0m
+ECC Curve Name:      prime256v1
+ECC Key Strength:    128[0m
+
 Subject:  itspeanutbutterjellytime.com
 Issuer:   /C=XX/ST=Nowhere in particular/L=Nowhere
 Not valid before: [32mDec 22 19:01:56 2019 GMT[0m


### PR DESCRIPTION
I had noticed that `docs.google.com` uses an ECC public key, but the curve name & key strength weren't being reported.  This PR fixes that.  Now we get:

```
$ ./sslscan docs.google.com
[...]
  SSL Certificate:
Signature Algorithm: sha256WithRSAEncryption
ECC Curve Name:      prime256v1
ECC Key Strength:    128
[...]
```