### PR TITLE
Update readme to remove note about OpenSSL v1.1.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,17 +85,6 @@ required to compile OpenSSL from source on OS X. Once you have, just run:
 
 ### OpenSSL issues
 
-#### OpenSSL 1.1.0 and later
-OpenSSL 1.1.0 introduced a number of significant changes, including the removal
-of old and insecure features such as SSLv2. While this is a very good thing for
-the SSL ecosystem as a whole, it is a problem for sslscan, which relies on
-these legacy features being available in order to detect them on client system.
-
-In order to work around this, sslscan builds against [Peter Mosmans'](https://github.com/PeterMosmans/openssl)
-fork of OpenSSL, which backports the Chacha20 and Poly1305 ciphers to OpenSSL
-1.0.2, while keeping the dangerous legacy features (such as SSLv2 and EXPORT
-ciphers) enabled.
-
 #### Statically linking a custom OpenSSL build
 
 It is possible to ignore the OpenSSL system installation and ship your own


### PR DESCRIPTION
The notes about OpenSSL v1.1.0 and Mosman's fork are obsolete.