### PR TITLE
Fix repeated cipher detection

### DIFF
--- a/sslscan.c
+++ b/sslscan.c
@@ -5212,7 +5212,7 @@ int testMissingCiphers(struct sslCheckOptions *options, unsigned int tls_version
     bs_free(&server_hello);
 
     /* Mark this cipher ID as supported by the server, so when we loop again, the next ciphersuite list doesn't include it. */
-    if( ! markFoundCiphersuite(cipher_id, tls_version)
+    if( ! markFoundCiphersuite(cipher_id, tls_version))
        goto done;
 
     /* Get the IANA name and cipher bit strength (maybe -1 when unknown). */

--- a/sslscan.h
+++ b/sslscan.h
@@ -322,7 +322,7 @@ bs *makeCiphersuiteListTLS13All();
 bs *makeCiphersuiteListMissing(unsigned int tls_version);
 bs *makeClientHello(struct sslCheckOptions *options, unsigned int version, bs *ciphersuite_list, bs *tls_extensions);
 bs *makeTLSExtensions(struct sslCheckOptions *options, unsigned int include_signature_algorithms);
-void markFoundCiphersuite(unsigned short server_cipher_id, unsigned int tls_version);
+int markFoundCiphersuite(unsigned short server_cipher_id, unsigned int tls_version);
 int ocsp_certid_print(BIO *bp, OCSP_CERTID *a, int indent);
 static int ocsp_resp_cb(SSL *s, void *arg);
 void readLine(FILE *, char *, int);


### PR DESCRIPTION
In our assessments we ran into servers that generated infinite lists of the same cipher, causing sslscan to loop forever.  By changing markFoundCipherSuite to return false if that cipher suite was already found, and then branching to done if that happens, we eliminated that issue.