### PR TITLE
Refactor printf_error to avoid needless cruft

### DIFF
--- a/sslscan.c
+++ b/sslscan.c
@@ -192,13 +192,13 @@ int populateCipherList(struct sslCheckOptions *options, const SSL_METHOD *sslMet
     SSL *ssl = NULL;
     options->ctx = new_CTX(sslMethod);
     if (options->ctx == NULL) {
-        printf_error("%sERROR: Could not create CTX object.%s\n", COL_RED, RESET);
+        printf_error("Could not create CTX object.");
         return false;
     }
     SSL_CTX_set_cipher_list(options->ctx, CIPHERSUITE_LIST_ALL);
     ssl = new_SSL(options->ctx);
     if (ssl == NULL) {
-        printf_error("%sERROR: Could not create SSL object.%s\n", COL_RED, RESET);
+        printf_error("Could not create SSL object.");
         FREE_CTX(options->ctx);
         return false;
     }
@@ -268,11 +268,11 @@ int readOrLogAndClose(int fd, void* buffer, size_t len, const struct sslCheckOpt
     n = recv(fd, buffer, len - 1, 0);
 
     if (n < 0 && errno != 11) {
-        printf_error("%s    ERROR: error reading from %s:%d: %s%s\n", COL_RED, options->host, options->port, strerror(errno), RESET);
+        printf_error("Error reading from %s:%d: %s", options->host, options->port, strerror(errno));
         close(fd);
         return 0;
     } else if (n == 0) {
-        printf_error("%s    ERROR: unexpected EOF reading from %s:%d%s\n", COL_RED, options->host, options->port, RESET);
+        printf_error("Unexpected EOF reading from %s:%d", options->host, options->port);
         close(fd);
         return 0;
     } else {
@@ -315,7 +315,7 @@ int tcpConnect(struct sslCheckOptions *options)
 
     if(socketDescriptor < 0)
     {
-        printf_error("%s    ERROR: Could not open a socket.%s\n", COL_RED, RESET);
+        printf_error("Could not open a socket.");
         return 0;
     }
 
@@ -340,7 +340,7 @@ int tcpConnect(struct sslCheckOptions *options)
 
     if(status < 0)
     {
-        printf_error("%sERROR: Could not open a connection to host %s (%s) on port %d.%s\n", COL_RED, options->host, options->addrstr, options->port, RESET);
+        printf_error("Could not open a connection to host %s (%s) on port %d.", options->host, options->addrstr, options->port);
         close(socketDescriptor);
         return 0;
     }
@@ -355,7 +355,7 @@ int tcpConnect(struct sslCheckOptions *options)
         if (strncmp(buffer, "220", 3) != 0)
         {
             close(socketDescriptor);
-            printf("%s    ERROR: The host %s on port %d did not appear to be an SMTP service.%s\n", COL_RED, options->host, options->port, RESET);
+            printf_error("The host %s on port %d did not appear to be an SMTP service.", options->host, options->port);
             return 0;
         }
         sendString(socketDescriptor, "EHLO example.org\r\n");
@@ -364,7 +364,7 @@ int tcpConnect(struct sslCheckOptions *options)
         if (strncmp(buffer, "250", 3) != 0)
         {
             close(socketDescriptor);
-            printf("%s    ERROR: The SMTP service on %s port %d did not respond with status 250 to our HELO.%s\n", COL_RED, options->host, options->port, RESET);
+            printf_error("The SMTP service on %s port %d did not respond with status 250 to our HELO.", options->host, options->port);
             return 0;
         }
         sendString(socketDescriptor, "STARTTLS\r\n");
@@ -373,7 +373,7 @@ int tcpConnect(struct sslCheckOptions *options)
         if (strncmp(buffer, "220", 3) != 0)
         {
             close(socketDescriptor);
-            printf("%s    ERROR: The SMTP service on %s port %d did not appear to support STARTTLS.%s\n", COL_RED, options->host, options->port, RESET);
+            printf_error("The SMTP service on %s port %d did not appear to support STARTTLS.", options->host, options->port);
             return 0;
         }
     }
@@ -546,12 +546,12 @@ int tcpConnect(struct sslCheckOptions *options)
             printf_verbose("STARTLS LDAP setup complete.\n");
         }
         else if (strstr(buffer, unsupported)) {
-            printf_error("%sSTARTLS LDAP connection to %s:%d failed with '%s'.%s\n",
-                         COL_RED, options->host, options->port, unsupported, RESET);
+            printf_error("STARTLS LDAP connection to %s:%d failed with '%s'.",
+                         options->host, options->port, unsupported);
             return 0;
         } else {
-            printf_error("%sSTARTLS LDAP connection to %s:%d failed with unknown error.%s\n",
-                         COL_RED, options->host, options->port, RESET);
+            printf_error("STARTLS LDAP connection to %s:%d failed with unknown error.",
+                         options->host, options->port);
             return 0;
         }
     }
@@ -589,12 +589,12 @@ int tcpConnect(struct sslCheckOptions *options)
 
         // Read reply byte
         if (1 != recv(socketDescriptor, &buffer, 1, 0)) {
-            printf_error("%s    ERROR: unexpected EOF reading from %s:%d%s\n", COL_RED, options->host, options->port, RESET);
+            printf_error("Unexpected EOF reading from %s:%d", options->host, options->port);
             return 0;
         }
 
         if (buffer != 'S') {
-            printf_error("%s    ERROR: server at %s:%d%s rejected TLS startup\n", COL_RED, options->host, options->port, RESET);
+            printf_error("Server at %s:%d rejected TLS startup", options->host, options->port);
             return 0;
         }
     }
@@ -613,21 +613,21 @@ int tcpConnect(struct sslCheckOptions *options)
 
         // Read reply header
         if (4 != recv(socketDescriptor, buffer, 4, 0)) {
-            printf_error("%s    ERROR: unexpected EOF reading from %s:%d%s\n", COL_RED, options->host, options->port, RESET);
+            printf_error("Unexpected EOF reading from %s:%d", options->host, options->port);
             return 0;
         }
 
         // Calculate remaining bytes (and check for overflows)
         readlen = ((buffer[2] & 0x7f) << 8) + buffer[3] - 4;
         if (readlen > sizeof(buffer)) {
-            printf_error("%s    ERROR: unexpected data from %s:%d%s\n", COL_RED, options->host, options->port, RESET);
+            printf_error("Unexpected data from %s:%d", options->host, options->port);
             return 0;
 
         }
 
         // Read reply data
         if (readlen != recv(socketDescriptor, buffer, readlen, 0)) {
-            printf_error("%s    ERROR: unexpected EOF reading from %s:%d%s\n", COL_RED, options->host, options->port, RESET);
+            printf_error("Unexpected EOF reading from %s:%d", options->host, options->port);
             return 0;
         }
     }
@@ -929,14 +929,14 @@ int testCompression(struct sslCheckOptions *options, const SSL_METHOD *sslMethod
                     else
                     {
                         status = false;
-                        printf_error("%s    ERROR: Could create SSL object.%s\n", COL_RED, RESET);
+                        printf_error("Could not create SSL object.");
                     }
                 }
             }
             else
             {
                 status = false;
-                printf_error("%s    ERROR: Could set cipher.%s\n", COL_RED, RESET);
+                printf_error("Could not set cipher.");
             }
             // Free CTX Object
             FREE_CTX(options->ctx);
@@ -945,7 +945,7 @@ int testCompression(struct sslCheckOptions *options, const SSL_METHOD *sslMethod
         else
         {
             status = false;
-            printf_error("%sERROR: Could not create CTX object.%s\n", COL_RED, RESET);
+            printf_error("Could not create CTX object.");
         }
 
         // Disconnect from host
@@ -954,7 +954,7 @@ int testCompression(struct sslCheckOptions *options, const SSL_METHOD *sslMethod
     else
     {
         // Could not connect
-        printf_error("%sERROR: Could not connect.%s\n", COL_RED, RESET);
+        printf_error("Could not connect.");
         status = false;
         exit(status);
     }
@@ -1098,14 +1098,14 @@ int testFallback(struct sslCheckOptions *options,  const SSL_METHOD *sslMethod)
                     else
                     {
                         status = false;
-                        printf_error("%s    ERROR: Could create SSL object.%s\n", COL_RED, RESET);
+                        printf_error("Could not create SSL object.");
                     }
                 }
             }
             else
             {
                 status = false;
-                printf_error("%s    ERROR: Could set cipher.%s\n", COL_RED, RESET);
+                printf_error("Could not set cipher.");
             }
             // Free CTX Object
             FREE_CTX(options->ctx);
@@ -1114,7 +1114,7 @@ int testFallback(struct sslCheckOptions *options,  const SSL_METHOD *sslMethod)
         else
         {
             status = false;
-            printf_error("%sERROR: Could not create CTX object.%s\n", COL_RED, RESET);
+            printf_error("Could not create CTX object.");
         }
 
         // Disconnect from host
@@ -1123,7 +1123,7 @@ int testFallback(struct sslCheckOptions *options,  const SSL_METHOD *sslMethod)
     else
     {
         // Could not connect
-        printf_error("%sERROR: Could not connect.%s\n", COL_RED, RESET);
+        printf_error("Could not connect.");
         status = false;
         exit(status);
     }
@@ -1253,7 +1253,7 @@ int testRenegotiation(struct sslCheckOptions *options, const SSL_METHOD *sslMeth
                                     res = SSL_do_handshake(ssl); // Send renegotiation request to server
                                     if( res != 1 )
                                     {
-                                        printf_error("\n\nSSL_do_handshake() call failed\n");
+                                        printf_error("SSL_do_handshake() call failed");
                                     }
                                     if (SSL_get_state(ssl) == TLS_ST_OK)
                                     {
@@ -1263,7 +1263,7 @@ int testRenegotiation(struct sslCheckOptions *options, const SSL_METHOD *sslMeth
                                     } else {
                                         renOut->supported = false;
                                         status = false;
-                                        printf_error("\n\nFailed to complete renegotiation\n");
+                                        printf_error("Failed to complete renegotiation");
                                     }
                                 } else {
                                     status = false;
@@ -1283,7 +1283,7 @@ int testRenegotiation(struct sslCheckOptions *options, const SSL_METHOD *sslMeth
                     {
                         status = false;
                         renOut->supported = false;
-                        printf_error("%s    ERROR: Could create SSL object.%s\n", COL_RED, RESET);
+                        printf_error("Could not create SSL object.");
                     }
                 }
             }
@@ -1291,7 +1291,7 @@ int testRenegotiation(struct sslCheckOptions *options, const SSL_METHOD *sslMeth
             {
                 status = false;
                 renOut->supported = false;
-                printf_error("%s    ERROR: Could set cipher.%s\n", COL_RED, RESET);
+                printf_error("Could not set cipher.");
             }
             // Free CTX Object
             FREE_CTX(options->ctx);
@@ -1301,7 +1301,7 @@ int testRenegotiation(struct sslCheckOptions *options, const SSL_METHOD *sslMeth
         {
             status = false;
             renOut->supported = false;
-            printf_error("%sERROR: Could not create CTX object.%s\n", COL_RED, RESET);
+            printf_error("Could not create CTX object.");
         }
 
         // Disconnect from host
@@ -1310,7 +1310,7 @@ int testRenegotiation(struct sslCheckOptions *options, const SSL_METHOD *sslMeth
     else
     {
         // Could not connect
-        printf_error("%sERROR: Could not connect.%s\n", COL_RED, RESET);
+        printf_error("Could not connect.");
         renOut->supported = false;
         status = false;
         freeRenegotiationOutput( renOut );
@@ -1374,7 +1374,7 @@ int testHeartbleed(struct sslCheckOptions *options, const SSL_METHOD *sslMethod)
             hello[10] = 0x03;
         }
         if (send(socketDescriptor, hello, sizeof(hello), 0) <= 0) {
-            printf_error("send() failed: %s\n", strerror(errno));
+            printf_error("send() failed: %s", strerror(errno));
             exit(1);
         }
 
@@ -1399,7 +1399,7 @@ int testHeartbleed(struct sslCheckOptions *options, const SSL_METHOD *sslMethod)
             hb[2] = 0x03;
         }
         if (send(socketDescriptor, hb, sizeof(hb), 0) <= 0) {
-            printf_error("send() failed: %s\n", strerror(errno));
+            printf_error("send() failed: %s", strerror(errno));
             exit(1);
         }
 
@@ -1458,7 +1458,7 @@ int testHeartbleed(struct sslCheckOptions *options, const SSL_METHOD *sslMethod)
     else
     {
         // Could not connect
-        printf_error("%sERROR: Could not connect.%s\n", COL_RED, RESET);
+        printf_error("Could not connect.");
         status = false;
         printf("dying");
         exit(status);
@@ -1811,7 +1811,7 @@ int testCipher(struct sslCheckOptions *options, const SSL_METHOD *sslMethod)
             else
             {
                 status = false;
-                printf("%s    ERROR: Could create SSL object.%s\n", COL_RED, RESET);
+                printf_error("Could not create SSL object.");
             }
         }
         else
@@ -1855,7 +1855,7 @@ int checkCertificateProtocol(struct sslCheckOptions *options, const SSL_METHOD *
     // Error Creating Context Object
     else
     {
-        printf_error("%sERROR: Could not create CTX object.%s\n", COL_RED, RESET);
+        printf_error("Could not create CTX object.");
         status = false;
     }
     return status;
@@ -2245,14 +2245,14 @@ int checkCertificate(struct sslCheckOptions *options, const SSL_METHOD *sslMetho
                     else
                     {
                         status = false;
-                        printf("%s    ERROR: Could not create SSL object.%s\n", COL_RED, RESET);
+                        printf_error("Could not create SSL object.");
                     }
                 }
             }
             else
             {
                 status = false;
-                printf("%s    ERROR: Could not set cipher.%s\n", COL_RED, RESET);
+                printf_error("Could not set cipher.");
             }
 
             // Free CTX Object
@@ -2262,7 +2262,7 @@ int checkCertificate(struct sslCheckOptions *options, const SSL_METHOD *sslMetho
         else
         {
             status = false;
-            printf_error("%sERROR: Could not create CTX object.%s\n", COL_RED, RESET);
+            printf_error("Could not create CTX object.");
         }
 
         // Disconnect from host
@@ -2388,14 +2388,14 @@ int ocspRequest(struct sslCheckOptions *options)
                     else
                     {
                         status = false;
-                        printf("%s    ERROR: Could not create SSL object.%s\n", COL_RED, RESET);
+                        printf_error("Could not create SSL object.");
                     }
                 }
             }
             else
             {
                 status = false;
-                printf("%s    ERROR: Could not set cipher.%s\n", COL_RED, RESET);
+                printf_error("Could not set cipher.");
             }
 
             // Free CTX Object
@@ -2405,7 +2405,7 @@ int ocspRequest(struct sslCheckOptions *options)
         else
         {
             status = false;
-            printf_error("%sERROR: Could not create CTX object.%s\n", COL_RED, RESET);
+            printf_error("Could not create CTX object.");
         }
 
         // Disconnect from host
@@ -2998,14 +2998,14 @@ int showCertificate(struct sslCheckOptions *options)
                     else
                     {
                         status = false;
-                        printf("%s    ERROR: Could create SSL object.%s\n", COL_RED, RESET);
+                        printf_error("Could not create SSL object.");
                     }
                 }
             }
             else
             {
                 status = false;
-                printf("%s    ERROR: Could set cipher.%s\n", COL_RED, RESET);
+                printf_error("Could not set cipher.");
             }
 
             // Free CTX Object
@@ -3016,7 +3016,7 @@ int showCertificate(struct sslCheckOptions *options)
         else
         {
             status = false;
-            printf_error("%sERROR: Could not create CTX object.%s\n", COL_RED, RESET);
+            printf_error("Could not create CTX object.");
         }
 
         // Disconnect from host
@@ -3166,14 +3166,14 @@ int showTrustedCAs(struct sslCheckOptions *options)
                     else
                     {
                         status = false;
-                        printf("%s    ERROR: Could create SSL object.%s\n", COL_RED, RESET);
+                        printf_error("Could not create SSL object.");
                     }
                 }
             }
             else
             {
                 status = false;
-                printf("%s    ERROR: Could set cipher.%s\n", COL_RED, RESET);
+                printf_error("Could not set cipher.");
             }
 
             // Free CTX Object
@@ -3184,7 +3184,7 @@ int showTrustedCAs(struct sslCheckOptions *options)
         else
         {
             status = false;
-            printf_error("%sERROR: Could not create CTX object.%s\n", COL_RED, RESET);
+            printf_error("Could not create CTX object.");
         }
 
         // Disconnect from host
@@ -3229,7 +3229,7 @@ int testConnection(struct sslCheckOptions *options)
     // Perform the actual lookup.
     if (getaddrinfo(options->host, NULL, &hints, &addrinfoResult) != 0)
     {
-        printf("%sERROR: Could not resolve hostname %s.%s\n", COL_RED, options->host, RESET);
+        printf_error("Could not resolve hostname %s.", options->host);
         return false;
     }
 
@@ -3307,7 +3307,7 @@ int testProtocolCiphers(struct sslCheckOptions *options, const SSL_METHOD *sslMe
         // Error Creating Context Object
         else
         {
-            printf_error("%sERROR: Could not create CTX object.%s\n", COL_RED, RESET);
+            printf_error("Could not create CTX object.");
             return false;
         }
     }
@@ -3708,7 +3708,7 @@ int main(int argc, char *argv[])
     err = WSAStartup(wVersionRequested, &wsaData);
     if (err != 0)
     {
-        printf_error("WSAStartup failed: %d\n", err);
+        printf_error("WSAStartup failed: %d", err);
         return -1;
     }
 #endif
@@ -4002,7 +4002,7 @@ int main(int argc, char *argv[])
                 options.port = strtol((hostString + tempInt), NULL, 10);
                 if (options.port < 1 || options.port > 65535)
                 {
-                    printf("\n%sInvalid target specified%s\n\n", COL_RED, RESET);
+                    printf_error("Invalid target specified.");
                     exit(1);
                 }
             }
@@ -4050,7 +4050,7 @@ int main(int argc, char *argv[])
             options.xmlOutput = fopen(argv[xmlArg] + 6, "w");
             if (options.xmlOutput == NULL)
             {
-                printf_error("%sERROR: Could not open XML output file %s.%s\n", COL_RED, argv[xmlArg] + 6, RESET);
+                printf_error("Could not open XML output file %s.", argv[xmlArg] + 6);
                 exit(0);
             }
         }
@@ -4180,7 +4180,7 @@ int main(int argc, char *argv[])
                     // Open targets file...
                     targetsFile = fopen(argv[options.targets] + 10, "r");
                     if (targetsFile == NULL)
-                        printf_error("%sERROR: Could not open targets file %s.%s\n", COL_RED, argv[options.targets] + 10, RESET);
+                        printf_error("Could not open targets file %s.", argv[options.targets] + 10);
                     else
                     {
                         readLine(targetsFile, line, sizeof(line));
@@ -4209,7 +4209,7 @@ int main(int argc, char *argv[])
                                     // Invalid port
                                     if (port == 0)
                                     {
-                                        printf_error("%sERROR: Invalid port specified.%s", COL_RED, RESET);
+                                        printf_error("Invalid port specified.");
                                         exit(1);
                                     }
                                     else
@@ -4235,7 +4235,7 @@ int main(int argc, char *argv[])
                     }
                 }
                 else
-                    printf_error("%sERROR: Targets file %s does not exist.%s\n", COL_RED, argv[options.targets] + 10, RESET);
+                    printf_error("Targets file %s does not exist.", argv[options.targets] + 10);
             }
 
             // Free Structures
@@ -4290,7 +4290,7 @@ int runSSLv2Test(struct sslCheckOptions *options) {
 
   /* Send the SSLv2 Client Hello packet. */
   if (send(s, sslv2_client_hello, sizeof(sslv2_client_hello), 0) <= 0) {
-    printf_error("send() failed: %s\n", strerror(errno));
+    printf_error("send() failed: %s", strerror(errno));
     exit(1);
   }
 
@@ -4433,7 +4433,7 @@ int runSSLv3Test(struct sslCheckOptions *options) {
 
   /* Send the SSLv3 Client Hello packet. */
   if (send(s, sslv3_client_hello_1, sizeof(sslv3_client_hello_1), 0) <= 0) {
-    printf_error("send() failed: %s\n", strerror(errno));
+    printf_error("send() failed: %s", strerror(errno));
     exit(1);
   }
 
@@ -4444,12 +4444,12 @@ int runSSLv3Test(struct sslCheckOptions *options) {
   timestamp_bytes[3] = (timestamp >> 24) & 0xff;
 
   if (send(s, timestamp_bytes, sizeof(timestamp_bytes), 0) <= 0) {
-    printf_error("send() failed: %s\n", strerror(errno));
+    printf_error("send() failed: %s", strerror(errno));
     exit(1);
   }
 
   if (send(s, sslv3_client_hello_2, sizeof(sslv3_client_hello_2), 0) <= 0) {
-    printf_error("send() failed: %s\n", strerror(errno));
+    printf_error("send() failed: %s", strerror(errno));
     exit(1);
   }
 
@@ -4775,7 +4775,7 @@ unsigned int checkIfTLSVersionIsSupported(struct sslCheckOptions *options, unsig
 
   /* Send the Client Hello message. */
   if (send(s, bs_get_bytes(client_hello), bs_get_len(client_hello), 0) <= 0) {
-    printf_error("send() failed while sending Client Hello: %d (%s)\n", errno, strerror(errno));
+    printf_error("send() failed while sending Client Hello: %d (%s)", errno, strerror(errno));
     goto done; /* Returns false. */
   }
   bs_free(&client_hello);
@@ -5192,7 +5192,7 @@ int testMissingCiphers(struct sslCheckOptions *options, unsigned int tls_version
 
     /* Send the Client Hello message. */
     if (send(s, bs_get_bytes(client_hello), bs_get_len(client_hello), 0) <= 0) {
-      printf_error("send() failed while sending Client Hello: %d (%s)\n", errno, strerror(errno));
+      printf_error("send() failed while sending Client Hello: %d (%s)", errno, strerror(errno));
       goto done; /* Returns false. */
     }
     bs_free(&client_hello);
@@ -5500,7 +5500,7 @@ int testSupportedGroups(struct sslCheckOptions *options) {
 
       /* Send the Client Hello message. */
       if (send(s, bs_get_bytes(client_hello), bs_get_len(client_hello), 0) <= 0) {
-        printf_error("send() failed while sending Client Hello: %d (%s)\n", errno, strerror(errno));
+        printf_error("send() failed while sending Client Hello: %d (%s)", errno, strerror(errno));
         ret = false;
         goto done;
       }
@@ -5730,7 +5730,7 @@ int testSignatureAlgorithms(struct sslCheckOptions *options) {
 
       /* Send the Client Hello message. */
       if (send(s, bs_get_bytes(client_hello), bs_get_len(client_hello), 0) <= 0) {
-        printf_error("send() failed while sending Client Hello: %d (%s)\n", errno, strerror(errno));
+        printf_error("send() failed while sending Client Hello: %d (%s)", errno, strerror(errno));
         ret = false;
         goto done;
       }

--- a/sslscan.c
+++ b/sslscan.c
@@ -955,8 +955,7 @@ int testCompression(struct sslCheckOptions *options, const SSL_METHOD *sslMethod
     {
         // Could not connect
         printf_error("Could not connect.");
-        status = false;
-        exit(status);
+        exit(1);
     }
 
     return status;
@@ -1124,8 +1123,7 @@ int testFallback(struct sslCheckOptions *options,  const SSL_METHOD *sslMethod)
     {
         // Could not connect
         printf_error("Could not connect.");
-        status = false;
-        exit(status);
+        exit(1);
     }
 
     // Call function again with downgraded protocol
@@ -1312,9 +1310,8 @@ int testRenegotiation(struct sslCheckOptions *options, const SSL_METHOD *sslMeth
         // Could not connect
         printf_error("Could not connect.");
         renOut->supported = false;
-        status = false;
         freeRenegotiationOutput( renOut );
-        exit(status);
+        exit(1);
     }
     outputRenegotiation(options, renOut);
     freeRenegotiationOutput( renOut );
@@ -1459,9 +1456,8 @@ int testHeartbleed(struct sslCheckOptions *options, const SSL_METHOD *sslMethod)
     {
         // Could not connect
         printf_error("Could not connect.");
-        status = false;
         printf("dying");
-        exit(status);
+        exit(1);
     }
 
     return status;

--- a/sslscan.h
+++ b/sslscan.h
@@ -74,7 +74,7 @@
 
 // Macros for various outputs
 #define printf(format, ...)         if (!xml_to_stdout) fprintf(stdout, format, ##__VA_ARGS__)
-#define printf_error(format, ...)   fprintf(stderr, format, ##__VA_ARGS__)
+#define printf_error(format, ...)   fprintf(stderr, "%sERROR: " format "%s\n", COL_RED, ##__VA_ARGS__, RESET)
 #define printf_xml(format, ...)     if (options->xmlOutput) fprintf(options->xmlOutput, format, ##__VA_ARGS__)
 #define printf_verbose(format, ...) if (options->verbose) printf(format, ##__VA_ARGS__)
 


### PR DESCRIPTION
This PR aims to cleanup `printf_error`, avoiding mixing the style with the content.
This should help in supporting `error` element for xml output - which I plan to do next, if you're ok with it :)