### PR TITLE
Disable Docker tests #9 & 10 since --http was removed.

### DIFF
--- a/docker_test.sh
+++ b/docker_test.sh
@@ -329,13 +329,15 @@ function run_test_8 {
 
 # Runs nginx with client certificate checking (signed by the CA in docker_test/ca_cert.pem).  sslscan will connect and make an HTTP request (--http).  The HTTP response code should be 200 to signify that the certificate was accepted.  Otherwise, nginx returns HTTP code 400 if no client certificates were presented.
 function run_test_9 {
-    run_test $1 '9' "/usr/sbin/nginx -c /etc/nginx/nginx_test9.conf" "--no-fallback --no-renegotiation --no-compression --no-heartbleed --certs=docker_test/cert_3072.crt --pk=docker_test/key_3072.pem --http"
+    #run_test $1 '9' "/usr/sbin/nginx -c /etc/nginx/nginx_test9.conf" "--no-fallback --no-renegotiation --no-compression --no-heartbleed --certs=docker_test/cert_3072.crt --pk=docker_test/key_3072.pem --http"
+    echo "Test #9 skipped."
 }
 
 
 # Runs nginx with client certificate checking, just as above.  Except this time, we connect with no certificate.  The HTTP response code should be "400 Bad Request".
 function run_test_10 {
-    run_test $1 '10' "/usr/sbin/nginx -c /etc/nginx/nginx_test9.conf" "--no-fallback --no-renegotiation --no-compression --no-heartbleed --http"
+    #run_test $1 '10' "/usr/sbin/nginx -c /etc/nginx/nginx_test9.conf" "--no-fallback --no-renegotiation --no-compression --no-heartbleed --http"
+    echo "Test #10 skipped."
 }
 
 


### PR DESCRIPTION
Turns out test #9 was using `--http` to ensure that client TLS certificates were being properly accepted by nginx.  It may be possible to determine client certificate acceptance another way, however.  In the meantime, these tests have been disabled.