### PR TITLE
Write SCSV Fallback to XML.

### DIFF
--- a/sslscan.c
+++ b/sslscan.c
@@ -1064,6 +1064,7 @@ int testFallback(struct sslCheckOptions *options,  const SSL_METHOD *sslMethod)
                             else
                             {
                                 printf("Server %sdoes not%s support TLS Fallback SCSV\n\n", COL_RED, RESET);
+                                printf_xml("  <fallback supported=\"0\" />\n");
                             }
                         }
                         else
@@ -1076,6 +1077,7 @@ int testFallback(struct sslCheckOptions *options,  const SSL_METHOD *sslMethod)
                                     if (SSL_get_error(ssl, connStatus == 6))
                                     {
                                         printf("Server %ssupports%s TLS Fallback SCSV\n\n", COL_GREEN, RESET);
+                                        printf_xml("  <fallback supported=\"1\" />\n");
                                         status = false;
                                     }
                                 }


### PR DESCRIPTION
The fallback SCSV was available in the xml a few years ago but I think was accidentally removed during a large commit. This PR uses the same xml format from when it was originally implemented.