### PR TITLE
Improve socket timeouts

### DIFF
--- a/sslscan.h
+++ b/sslscan.h
@@ -192,6 +192,7 @@ struct sslCheckOptions
     struct sockaddr_in serverAddress;
     struct sockaddr_in6 serverAddress6;
     struct timeval timeout;
+    int connect_timeout;
     unsigned int sleep;
 
     // SSL Variables...


### PR DESCRIPTION
This change adds connect timeouts (settable with `--connect-timeout`) in a portable way (by putting socket in non-blocking mode, then calling connect/select).

Additionally, `--timeout` now sets both send and receive socket timeouts. Connect error message now gives a reason why connection failed (e.g. "Connection refused").

These changes should be compatible with both Linux and Windows (tested with Mingw build).