### PR TITLE
RFC Cipher Names

### DIFF
--- a/sslscan.c
+++ b/sslscan.c
@@ -1746,28 +1746,28 @@ void outputCipher(struct sslCheckOptions *options, SSL *ssl, const char *cleanSs
 
     printf_xml(" bits=\"%d\" cipher=\"%s\" id=\"%s\"", cipherbits, ciphername, hexCipherId);
     if (strstr(ciphername, "NULL")) {
-        printf("%s%-29s%s", COL_RED_BG, ciphername, RESET);
+        printf("%s%-45s%s", COL_RED_BG, ciphername, RESET);
         strength = "null";
     } else if (strstr(ciphername, "ADH") || strstr(ciphername, "AECDH") || strstr(ciphername, "_anon_")) {
-        printf("%s%-29s%s", COL_PURPLE, ciphername, RESET);
+        printf("%s%-45s%s", COL_PURPLE, ciphername, RESET);
         strength = "anonymous";
     } else if (strstr(ciphername, "EXP")) {
-        printf("%s%-29s%s", COL_RED, ciphername, RESET);
+        printf("%s%-45s%s", COL_RED, ciphername, RESET);
         strength = "weak";
     } else if (strstr(ciphername, "RC4") || strstr(ciphername, "DES")) {
-        printf("%s%-29s%s", COL_YELLOW, ciphername, RESET);
+        printf("%s%-45s%s", COL_YELLOW, ciphername, RESET);
         strength = "medium";
     } else if (strstr(ciphername, "_SM4_")) { /* Developed by Chinese government */
-        printf("%s%-29s%s", COL_YELLOW, ciphername, RESET);
+        printf("%s%-45s%s", COL_YELLOW, ciphername, RESET);
         strength = "medium";
     } else if (strstr(ciphername, "_GOSTR341112_")) { /* Developed by Russian government */
-        printf("%s%-29s%s", COL_YELLOW, ciphername, RESET);
+        printf("%s%-45s%s", COL_YELLOW, ciphername, RESET);
         strength = "medium";
     } else if ((strstr(ciphername, "CHACHA20") || (strstr(ciphername, "GCM"))) && strstr(ciphername, "DHE")) {
-        printf("%s%-29s%s", COL_GREEN, ciphername, RESET);
+        printf("%s%-45s%s", COL_GREEN, ciphername, RESET);
         strength = "strong";
     } else {
-        printf("%-29s", ciphername);
+        printf("%-45s", ciphername);
         strength = "acceptable";
     }
     printf_xml(" strength=\"%s\"", strength);
@@ -1848,7 +1848,15 @@ int testCipher(struct sslCheckOptions *options, const SSL_METHOD *sslMethod)
                 cipherid = SSL_CIPHER_get_id(sslCipherPointer);
                 cipherid = cipherid & 0x00ffffff;  // remove first byte which is the version (0x03 for TLSv1/SSLv3)
 
-                ciphername = SSL_CIPHER_get_name(sslCipherPointer);
+                if (options->rfcNames)
+                {
+                    ciphername = SSL_CIPHER_standard_name(sslCipherPointer);
+                }
+                else
+                {
+                    ciphername = SSL_CIPHER_get_name(sslCipherPointer);
+                }
+                
 
 		// Timing
 		if (options->showTimes) {
@@ -3922,6 +3930,10 @@ int main(int argc, char *argv[])
         else if (strcmp("--show-sigs", argv[argLoop]) == 0)
             options->signature_algorithms = true;
 
+        // Show RFC algorithms names in output
+        else if (strcmp("--show-rfc-names", argv[argLoop]) == 0)
+            options->rfcNames = true;
+
         // StartTLS... FTP
         else if (strcmp("--starttls-ftp", argv[argLoop]) == 0)
             options->starttls_ftp = true;
@@ -4185,6 +4197,7 @@ int main(int argc, char *argv[])
             printf("\n");
             printf("  %s--show-certificate%s   Show full certificate information\n", COL_GREEN, RESET);
             printf("  %s--show-client-cas%s    Show trusted CAs for TLS client auth\n", COL_GREEN, RESET);
+            printf("  %s--show-rfc-names%s   Show RFC cipher names instead of OpenSSL\n", COL_GREEN, RESET);
             printf("  %s--no-check-certificate%s  Don't warn about weak certificate algorithm or keys\n", COL_GREEN, RESET);
             printf("  %s--ocsp%s               Request OCSP response from server\n", COL_GREEN, RESET);
             printf("  %s--pk=<file>%s          A file containing the private key or a PKCS#12 file\n", COL_GREEN, RESET);

--- a/sslscan.h
+++ b/sslscan.h
@@ -182,6 +182,7 @@ struct sslCheckOptions
     int ipv4;
     int ipv6;
     int ocspStatus;
+    int rfcNames;
     char cipherstring[65536];
 
     // File Handles...


### PR DESCRIPTION
Add command line switch to show RFC cipher names instead of the OpenSSL names.
By using the command line switch "--show-rfc-names" the RFC cipher names are shown in console output as well as inside the XML output. 