### PR TITLE
Do not print certificate end tag without a starting tag

### DIFF
--- a/sslscan.c
+++ b/sslscan.c
@@ -2362,13 +2362,13 @@ int checkCertificate(struct sslCheckOptions *options, const SSL_METHOD *sslMetho
                             X509_free(x509Cert);
                             // This is abusing status a bit, but means that we'll only get the cert once
                             status = false;
+
+                            printf_xml("  </certificate>\n");
                         }
 
                         else {
                             printf("    Unable to parse certificate\n");
                         }
-
-                        printf_xml("  </certificate>\n");
 
                         // Free BIO
                         BIO_free(stdoutBIO);


### PR DESCRIPTION
The printf_xml is simply outside of the if block that generates the start tag (when x509Cert != NULL).