### PR TITLE
Docker multi-stage scratch build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,31 @@
-FROM alpine:latest
+FROM alpine:latest as builder
 
-RUN apk update
-RUN apk add gcc make ca-certificates git libc-dev linux-headers openssl perl zlib-dev
+# Ensure no packages are cached before we try to do an update.
+RUN apk cache clean 2> /dev/null || exit 0
 
+RUN apk update && apk add gcc make ca-certificates git libc-dev linux-headers openssl perl zlib-dev
 RUN update-ca-certificates
-ADD . builddir
-RUN cd builddir; make static; cp /builddir/sslscan /usr/local/bin
 
-ENTRYPOINT ["sslscan"]
+ADD . builddir
+
+# Make a static build of sslscan, then strip it of debugging symbols.
+RUN cd builddir && make static
+RUN strip --strip-all /builddir/sslscan
+
+# Print the output of ldd so we can see what dynamic libraries that sslscan is still dependent upon.
+RUN echo "ldd output:" && ldd /builddir/sslscan
+RUN echo "ls -al output:" && ls -al /builddir/sslscan
+
+
+# Start with an empty container for our final build.
+FROM scratch
+
+# Copy over the sslscan executable from the intermediate build container, along with the dynamic libraries it is dependent upon (see output of ldd, above).
+COPY --from=builder /builddir/sslscan /sslscan
+COPY --from=builder /lib/libz.so.1 /lib/libz.so.1
+COPY --from=builder /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+
+# Drop root privileges.
+USER 65535:65535
+
+ENTRYPOINT ["/sslscan"]


### PR DESCRIPTION
This PR converts the Dockerfile into a multi-stage scratch build.  While Alpine Linux is indeed only 7MB, after installing gcc & support libraries and compiling OpenSSL in the container, the result is 743MB.  The multi-stage scratch build cuts this down to about 4MB(!) by eliminating all files except the static executable and two dependent dynamic libraries.

The resulting container is also now run without root privileges (note that containers run as root by default, unless an explicit `USER` directive drops privileges!).