### PR TITLE
Build multi-arch image and push it into gh container registry.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+---
 name: ci
 
 on: push
@@ -28,3 +29,35 @@ jobs:
       - name: build with mingw-w64
         run: |
           make -f Makefile.mingw
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          pull: true
+          push: true
+          platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: .
+          file: Dockerfile
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,17 @@
-FROM alpine:latest as builder
+FROM alpine:3.17.2 as builder
 
-# Ensure no packages are cached before we try to do an update.
-RUN apk cache clean 2> /dev/null || exit 0
+# hadolint ignore=DL3018
+RUN apk add --no-cache gcc make ca-certificates git libc-dev linux-headers openssl perl zlib-dev && update-ca-certificates
 
-RUN apk update && apk add gcc make ca-certificates git libc-dev linux-headers openssl perl zlib-dev
-RUN update-ca-certificates
-
-ADD . builddir
+COPY . /builddir
 
 # Make a static build of sslscan, then strip it of debugging symbols.
-RUN cd builddir && make static
-RUN strip --strip-all /builddir/sslscan
-
-# Print the output of ldd so we can see what dynamic libraries that sslscan is still dependent upon.
-RUN echo "ldd output:" && ldd /builddir/sslscan
-RUN echo "ls -al output:" && ls -al /builddir/sslscan
-
+WORKDIR /builddir
+ARG TARGETARCH
+RUN archwrapper="" && \
+    if [ "$TARGETARCH" = "386" ] ; then archwrapper="linux32" ; fi && \
+    $archwrapper make static && strip --strip-all sslscan && \
+    echo "ldd output:" && ldd sslscan && echo "ls -al output:" && ls -al sslscan # Print the output of ldd so we can see what dynamic libraries that sslscan is still dependent upon.
 
 # Start with an empty container for our final build.
 FROM scratch
@@ -23,7 +19,7 @@ FROM scratch
 # Copy over the sslscan executable from the intermediate build container, along with the dynamic libraries it is dependent upon (see output of ldd, above).
 COPY --from=builder /builddir/sslscan /sslscan
 COPY --from=builder /lib/libz.so.1 /lib/libz.so.1
-COPY --from=builder /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --from=builder /lib/ld-musl-*.so.1 /lib/
 
 # Drop root privileges.
 USER 65535:65535


### PR DESCRIPTION
This will build x86, x86_64, armv7 and aarch64 images and push them into
the github container registry.

I've also tidied the outstanding hadolint warnings.