### PR TITLE
Set NUM_PROCS correctly on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,9 @@ NUM_PROCS = 1
 ifneq (,$(wildcard /usr/bin/nproc))
 	NUM_PROCS = `/usr/bin/nproc --all`
 endif
-
+ifeq ($(OS), Darwin)
+	NUM_PROCS = `/usr/sbin/system_profiler SPHardwareDataType | /usr/bin/grep "Total Number of Cores" | /usr/bin/awk -F: '{print $$2}'`
+endif
 
 .PHONY: all sslscan clean install uninstall static opensslpull
 


### PR DESCRIPTION
The current Makefile doesn't support MacOS when it comes to setting NUM_PROCS (as MacOS doesn't supply an "nproc" binary); which means that an OpenSSL compile (i.e. "make static") on MacOS only uses a single thread/cpu.

This PR will include a definition for MacOS to set NUM_PROCS correctly.