### PR TITLE
Fix zlib MinGW build

### DIFF
--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -66,7 +66,7 @@ zlibpull:
 	if [ -d zlib_mingw -a -d zlib_mingw/.git ]; then \
 		cd ./zlib_mingw && git pull && git checkout tags/`git describe --abbrev=0 --tags` ; \
 	else \
-		git clone --depth 1 https://github.com/madler/zlib ./zlib_mingw && cd ./zlib_mingw && git checkout tags/`git describe --abbrev=0` ; \
+		git clone -b master --depth 1 https://github.com/madler/zlib ./zlib_mingw && cd ./zlib_mingw && git checkout tags/`git describe --abbrev=0` ; \
 	fi
 
 opensslpull:


### PR DESCRIPTION
Zlib's default branch has changed from `master` to `develop`.  This causes the MinGW build to fail.

The fix is very simple: we just need to explicitly check out `master`.