### PR TITLE
Fixed Docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ opensslpull:
 	if [ -d openssl -a -d openssl/.git ]; then \
 		cd ./openssl && git checkout `git ls-remote https://github.com/openssl/openssl | grep -Eo '(openssl-3\.0\.[0-9]+)' | sort --version-sort | tail -n 1` && git pull | grep -q "Already up-to-date." && [ -e ../.openssl.is.fresh ] || touch ../.openssl.is.fresh ; \
 	else \
-	git clone --depth 1 -b `git ls-remote https://github.com/openssl/openssl | grep -Eo '(openssl-3\.0\.[0-9]+)' | sort --version-sort | tail -n 1` https://github.com/openssl/openssl ./openssl && cd ./openssl && touch ../.openssl.is.fresh ; \
+	git clone --depth 1 -b `git ls-remote https://github.com/openssl/openssl | grep -Eo '(openssl-3\.0\.[0-9]+)' | sort -V | tail -n 1` https://github.com/openssl/openssl ./openssl && cd ./openssl && touch ../.openssl.is.fresh ; \
 	fi
 
 # Need to build OpenSSL differently on OSX


### PR DESCRIPTION
This fixes the Docker building problem reported in #290.

The normal `sort` program has a `--version-sort` argument, and works just fine during a host-based build.  However, when building in Docker, the `alpine` image is used during the build stage; the `sort` command there is handled by busybox, which doesn't offer this flag.  Both versions of `sort` support `-V` for version sorting, however.