### PR TITLE
Fixed certificate parsing against some servers. (#298)

### DIFF
--- a/sslscan.c
+++ b/sslscan.c
@@ -2033,6 +2033,9 @@ int checkCertificate(struct sslCheckOptions *options, const SSL_METHOD *sslMetho
                         SSL_set_tlsext_host_name (ssl, options->sniname);
 #endif
 
+                        // Against some servers, this is required for a successful SSL_connect(), below.
+                        SSL_set_options(ssl, SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION);
+
                         // Connect SSL over socket
                         SSL_connect(ssl);
                         // Setup BIO's

--- a/sslscan.c
+++ b/sslscan.c
@@ -1869,6 +1869,9 @@ int testCipher(struct sslCheckOptions *options, const SSL_METHOD *sslMethod)
                 // This enables TLS SNI
                 SSL_set_tlsext_host_name (ssl, options->sniname);
 
+                // Against some servers, this is required for a successful SSL_connect(), below.
+                SSL_set_options(ssl, SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION);
+
                 // Connect SSL over socket
                 cipherStatus = SSL_connect(ssl);
                 printf_verbose("SSL_connect() returned: %d\n", cipherStatus);


### PR DESCRIPTION
This fixes the certificate parsing failure reported in #298.

An investigation showed that the local OpenSSL library was terminating the connection since the server wanted to do an insecure legacy renegotiation.  Since sslscan is just a testing application and doesn't create TLS connections for actually transporting sensitive data, it seems like enabling this should be fine.