### PR TITLE
Fix Docker build for non-x86_64 architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ FROM scratch
 # Copy over the sslscan executable from the intermediate build container, along with the dynamic libraries it is dependent upon (see output of ldd, above).
 COPY --from=builder /builddir/sslscan /sslscan
 COPY --from=builder /lib/libz.so.1 /lib/libz.so.1
-COPY --from=builder /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --from=builder /lib/ld-musl-*.so.1 /lib/
 
 # Drop root privileges.
 USER 65535:65535


### PR DESCRIPTION
As reported in #300, the Docker build fails on non-x86_64 architectures.  This PR updates the `Dockerfile` to not assume the build machine is x86_64.