### PR TITLE
Enable 'quiet shutdown' on the SSL context

### DIFF
--- a/sslscan.c
+++ b/sslscan.c
@@ -171,6 +171,7 @@ SSL_CTX *new_CTX(const SSL_METHOD *method) {
   SSL_CTX *ret = SSL_CTX_new(method);
   SSL_CTX_set_security_level(ret, 0);
   SSL_CTX_set_security_callback(ret, security_callback_allow_all);
+  SSL_CTX_set_quiet_shutdown(ret, 1);
   return ret;
 }
 


### PR DESCRIPTION
I've encountered quite a few situations where the remote server disconnects the client before `SSL_shutdown` is called.

For TLSv1.3 `SSL_shutdown` expects to send a `close_notify` to the server - which it cannot do as the connection is gone. This causes sslscan to die with `SIGPIPE` signal.

This PR adds a configures the SSL Context with quiet shutdown which means that calling `SSL_shutdown` won't attempt to send the `close_notify` to the server - thus avoiding the `SIGPIPE` problem. This greatly to improves the scanning experience for some TLSv1.3 servers.
