### PR TITLE
Build on cygwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,9 @@ CFLAGS  += -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIE
 # Don't enable some hardening flags on OS X because it uses an old version of Clang
 ifneq ($(OS), Darwin)
 ifneq ($(OS), SunOS)
+ifneq ($(findstring CYGWIN,$(OS)),CYGWIN)
 	LDFLAGS += -pie -z relro -z now
+endif
 endif
 endif
 


### PR DESCRIPTION
```
$ uname -srvmpio
CYGWIN_NT-10.0-22000 3.5.0-1.x86_64 2024-02-01 11:02 UTC x86_64 unknown unknown Cygwin
$ cd /usr/src
$ git clone https://github.com/rbsec/sslscan.git
$ cd sslscan
$ make
$ cc -o sslscan -Wall -Wformat=2 -Wformat-security -Wno-deprecated-declarations -pie -z relro -z now -L/usr/local/lib -L/usr/local/ssl/lib -L/usr/local/opt/openssl/lib -L/opt/local/lib -D_FORTIFY_SOURCE=2 -fstack-protector-all -fPIE -std=gnu11 -I/usr/local/include -I/usr/local/ssl/include -I/usr/local/ssl/include/openssl -I/usr/local/opt/openssl/include -I/opt/local/include -I/opt/local/include/openssl  -DVERSION=\"2.1.3-1-gc1e3d1b\" sslscan.c -lssl -lcrypto -ldl
/usr/lib/gcc/x86_64-pc-cygwin/11/../../../../x86_64-pc-cygwin/bin/ld: unrecognized option '-z'
/usr/lib/gcc/x86_64-pc-cygwin/11/../../../../x86_64-pc-cygwin/bin/ld: use the --help option for usage information
collect2: error: ld returned 1 exit status
make: *** [Makefile:106: sslscan] Error 1
```
