### PR TITLE
Added --show-certificates option. Fixes #307

### DIFF
--- a/sslscan.h
+++ b/sslscan.h
@@ -151,6 +151,7 @@ struct sslCheckOptions
     char addrstr[INET6_ADDRSTRLEN];
     int port;
     int showCertificate;
+    int showCertificates;
     int checkCertificate;
     int showTrustedCAs;
     int showClientCiphers;


### PR DESCRIPTION
Added a --show-certificates option to show all certificates returned by remote server. Typically the intermediate(s) and the web-server one. Useful to check if the remote server is returning all the required certificates and to check is anyone is expired.
Despite the long git diff (perhaps because of the indentation), the source code modifications are very simple:
  - SSL_get_peer_cert_chain(ssl) or SSL_get_peer_certificate(ssl) depending on the options selected
  - a for cycle over the list of certificates