### PR TITLE
Build system quality of life changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ ifeq ($(OS), Darwin)
 	NUM_PROCS = `sysctl -n hw.ncpu`
 endif
 
-.PHONY: all sslscan clean install uninstall static opensslpull
+.PHONY: all sslscan clean realclean install uninstall static opensslpull
 
 all: sslscan
 	@echo
@@ -176,6 +176,8 @@ test:	static
 	./docker_test.sh
 
 clean:
-	if [ -d openssl ]; then ( rm -rf openssl ); fi;
 	rm -f sslscan
+
+realclean: clean
+	if [ -d openssl ]; then ( rm -rf openssl ); fi;
 	rm -f .openssl.is.fresh

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ uninstall:
 	true
 opensslpull:
 	if [ -d openssl -a -d openssl/.git ]; then \
-		cd ./openssl && git checkout `git ls-remote https://github.com/openssl/openssl | grep -Eo '(openssl-3\.0\.[0-9]+)' | sort --version-sort | tail -n 1` && git pull | grep -q "Already up-to-date." && [ -e ../.openssl.is.fresh ] || touch ../.openssl.is.fresh ; \
+		cd ./openssl && git checkout `git ls-remote https://github.com/openssl/openssl | grep -Eo '(openssl-3\.0\.[0-9]+)' | sort --version-sort | tail -n 1` && git pull | grep -q "Already up to date." && [ -e ../.openssl.is.fresh ] || touch ../.openssl.is.fresh ; \
 	else \
 	git clone --depth 1 -b `git ls-remote https://github.com/openssl/openssl | grep -Eo '(openssl-3\.0\.[0-9]+)' | sort -V | tail -n 1` https://github.com/openssl/openssl ./openssl && cd ./openssl && touch ../.openssl.is.fresh ; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -146,20 +146,8 @@ opensslpull:
 	git clone --depth 1 -b `git ls-remote https://github.com/openssl/openssl | grep -Eo '(openssl-3\.0\.[0-9]+)' | sort -V | tail -n 1` https://github.com/openssl/openssl ./openssl && cd ./openssl && touch ../.openssl.is.fresh ; \
 	fi
 
-# Need to build OpenSSL differently on OSX
-ifeq ($(OS), Darwin)
-ifeq ($(ARCH), arm64)
-OSSL_TARGET=darwin64-arm64-cc
-else
-OSSL_TARGET=darwin64-x86_64-cc
-endif
 openssl/Makefile: .openssl.is.fresh
-	cd ./openssl; ./Configure -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIC enable-weak-ssl-ciphers zlib $(OSSL_TARGET)
-# Any other *NIX platform
-else
-openssl/Makefile: .openssl.is.fresh
-	cd ./openssl; ./config -v -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIC no-shared enable-weak-ssl-ciphers zlib
-endif
+	cd ./openssl; ./Configure -v -fstack-protector-all -D_FORTIFY_SOURCE=2 -fPIC no-shared enable-weak-ssl-ciphers zlib
 
 openssl/libcrypto.a: openssl/Makefile
 	$(MAKE) -j $(NUM_PROCS) -C openssl depend


### PR DESCRIPTION
A couple of small build system quality of life improvements.

Fix the git "up to date" checking. It was incorrectly always deciding it needed updating.
Breakout the clean target to clean and realclean. Only delete openssl on realclean.
Simply the openssl configuration logic. There is no need for a special case for Darwin here.