### PR TITLE
Fix bash commands formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,11 @@ Ensure that you local Docker installation is functional, and the build the conta
 
 Or manually with:
 
-   docker build -t sslscan:sslscan .
+    docker build -t sslscan:sslscan .
 
 You can then run sslscan with:
 
-   docker run --rm -ti sslscan:sslscan --help
+    docker run --rm -ti sslscan:sslscan --help
 
 ### Building on Windows
 


### PR DESCRIPTION
This PR fixes bash commands formatting in README file
by fixing indentation.

Before:
![image](https://github.com/rbsec/sslscan/assets/41443370/49dce706-580d-407b-8951-4155de9431c3)

After:
![image](https://github.com/rbsec/sslscan/assets/41443370/20cf4e4b-d095-4619-a423-db6248ec99fc)
