### PR TITLE
Bump actions/checkout to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         cc: [clang, gcc]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: build with ${{ matrix.cc }}
         run: |
           make sslscan
@@ -20,7 +20,7 @@ jobs:
   build_mingw:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: install mingw-w64
         run: |
           sudo apt-get update -qq


### PR DESCRIPTION
Fixes deprecation warnings
`The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2`
`The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v2.`