### PR TITLE
Cleanup update logic for embedded openssl git tree.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,8 @@ uninstall:
 	rm -f $(DESTDIR)$(MAN1DIR)/sslscan.1
 
 .openssl.is.fresh: opensslpull
-	true
+	@true
+
 opensslpull:
 	upstream=`git ls-remote https://github.com/openssl/openssl | grep -Eo '(openssl-3\.0\.[0-9]+)' | sort -V | tail -n 1` ; \
 	if [ -d openssl -a -d openssl/.git ]; then \

--- a/Makefile
+++ b/Makefile
@@ -140,10 +140,13 @@ uninstall:
 .openssl.is.fresh: opensslpull
 	true
 opensslpull:
+	upstream=`git ls-remote https://github.com/openssl/openssl | grep -Eo '(openssl-3\.0\.[0-9]+)' | sort -V | tail -n 1` ; \
 	if [ -d openssl -a -d openssl/.git ]; then \
-		cd ./openssl && git checkout `git ls-remote https://github.com/openssl/openssl | grep -Eo '(openssl-3\.0\.[0-9]+)' | sort --version-sort | tail -n 1` && git pull | grep -q "Already up to date." && [ -e ../.openssl.is.fresh ] || touch ../.openssl.is.fresh ; \
+		if [ "$$upstream" != "`cd ./openssl && git describe --exact-match --tags`" ]; then \
+			cd ./openssl && git fetch --depth 1 origin refs/tags/$$upstream:refs/tags/$$upstream && git checkout $$upstream && touch ../.openssl.is.fresh ; \
+		fi \
 	else \
-	git clone --depth 1 -b `git ls-remote https://github.com/openssl/openssl | grep -Eo '(openssl-3\.0\.[0-9]+)' | sort -V | tail -n 1` https://github.com/openssl/openssl ./openssl && cd ./openssl && touch ../.openssl.is.fresh ; \
+		git clone --depth 1 -b $$upstream https://github.com/openssl/openssl ./openssl && cd ./openssl && touch ../.openssl.is.fresh ; \
 	fi
 
 openssl/Makefile: .openssl.is.fresh


### PR DESCRIPTION
The pipeline to update the embedded openssl tree has a logic error and cannot checkout a tag that isn't in the local repository. This errors out causing the embedded tree to never be updated.

To reproduce checkout an older tree (3.0.14) and see how it doesn't properly update:
```
$ rm -rf openssl
$ git clone --depth 1 -b openssl-3.0.14 https://github.com/openssl/openssl ./openssl
<cloning messages here>
$ make opensslpull
...
error: pathspec 'openssl-3.0.15' did not match any file(s) known to git
```

This change properly fetches the new tag and will then properly check it out. With the updated Makefile:
```
$ rm -rf openssl
$ git clone --depth 1 -b openssl-3.0.14 https://github.com/openssl/openssl ./openssl
<cloning messages here>
$ make opensslpull
<happy fetching messages>
From https://github.com/openssl/openssl
 * [new tag]           openssl-3.0.15 -> openssl-3.0.15
Previous HEAD position was 9cff14fd Prepare for release of 3.0.14
HEAD is now at c523121f Prepare for release of 3.0.15
```

I'm maintaining the shallow clone behavior and doing the fetch with `--depth 1` which makes it about as minimal as possible. Updating from 3.0.14 to 3.0.15 transferred 64KiB on the wire, according to git.