### PR TITLE
Bring sslscan into a OpenSSL 3.x world

### DIFF
--- a/sslscan.c
+++ b/sslscan.c
@@ -794,16 +794,8 @@ int loadCerts(struct sslCheckOptions *options)
             {
                 if (!SSL_CTX_use_PrivateKey_file(options->ctx, options->privateKeyFile, SSL_FILETYPE_ASN1))
                 {
-                    // Why would the more specific functions succeed if the generic functions failed?
-                    // -- I'm guessing that the original author was hopeful? - io
-                    if (!SSL_CTX_use_RSAPrivateKey_file(options->ctx, options->privateKeyFile, SSL_FILETYPE_PEM))
-                    {
-                        if (!SSL_CTX_use_RSAPrivateKey_file(options->ctx, options->privateKeyFile, SSL_FILETYPE_ASN1))
-                        {
-                            printf("%s    Could not configure private key.%s\n", COL_RED, RESET);
-                            status = 0;
-                        }
-                    }
+                    printf("%s    Could not configure private key.%s\n", COL_RED, RESET);
+                    status = 0;
                 }
             }
         }

--- a/sslscan.c
+++ b/sslscan.c
@@ -4138,14 +4138,14 @@ int main(int argc, char *argv[])
     {
         case mode_version:
             printf("%s\t\t%s\n\t\t%s\n%s", COL_BLUE, VERSION,
-                    SSLeay_version(SSLEAY_VERSION), RESET);
+                    OpenSSL_version(OPENSSL_VERSION), RESET);
             break;
 
         case mode_help:
             // Program version banner...
             printf("%s%s%s\n", COL_BLUE, program_banner, RESET);
             printf("%s\t\t%s\n\t\t%s\n%s\n\n", COL_BLUE, VERSION,
-                    SSLeay_version(SSLEAY_VERSION), RESET);
+                    OpenSSL_version(OPENSSL_VERSION), RESET);
             printf("%sCommand:%s\n", COL_BLUE, RESET);
             printf("  %s%s [options] [host:port | host]%s\n\n", COL_GREEN, argv[0], RESET);
             printf("%sOptions:%s\n", COL_BLUE, RESET);
@@ -4216,7 +4216,7 @@ int main(int argc, char *argv[])
         case mode_single:
         case mode_multiple:
             printf("Version: %s%s%s\n%s\n%s\n", COL_GREEN, VERSION, RESET,
-                    SSLeay_version(SSLEAY_VERSION), RESET);
+                    OpenSSL_version(OPENSSL_VERSION), RESET);
 
             ERR_load_crypto_strings();
 


### PR DESCRIPTION
This set of code changes drags sslscan kicking and screaming into the modern era with OpenSSL. There isn't any functional code changes, it's mostly purging old ifdef's and dropping old code that has runtime detection for ancient versions of OpenSSL.

This also moves over several calls that have drop-in modern methods.

Still outstanding deprecated feature usage will require deeper code changes to deal with. Specifically protocol versioned SSL_METHOD (which is sprinkled absolutely everywhere in the codebase) and moving away from key type specific object (EC_KEY, DH, RSA, etc) to the generic EVP_PKEY framework.