### PR TITLE
Add Handshake Backup When Primary Protocol Detection Fails

### DIFF
--- a/sslscan.h
+++ b/sslscan.h
@@ -318,6 +318,7 @@ void bs_set_byte(bs *, size_t, unsigned char);
 void bs_set_ushort(bs *b, size_t offset, unsigned short length);
 int bs_read_socket(bs *b, int s, size_t num_bytes);
 unsigned int checkIfTLSVersionIsSupported(struct sslCheckOptions *options, unsigned int tls_version);
+unsigned int checkIfTLSVersionIsSupported_Backup(struct sslCheckOptions *options, unsigned int tls_version);
 SSL_CTX *CTX_new(const SSL_METHOD *method);
 int fileExists(char *);
 void findMissingCiphers();


### PR DESCRIPTION
A user reported in #334 that TLSv1.2 was not being detected on a target. An investigation found that the target was terminating the connection because our constructed ClientHello includes a high number of ciphersuites (351; this is to increase the chances of a server responding).  I strongly suspect this server behavior is not conformant to the TLS specs, but regardless, this PR works around the issue by making a second handshake attempt using OpenSSL's built-in functions (which include only 28 ciphersuites in the ClientHello message).

This workaround may be useful for detecting other non-standard TLS implementations as well.