### PR TITLE
Docker test system update

### DIFF
--- a/docker_test.sh
+++ b/docker_test.sh
@@ -1,34 +1,20 @@
 #!/bin/bash
 
 #
-# Copyright (C) 2019-2020  Joe Testa <jtesta@positronsecurity.com>
+# Copyright (C) 2019-2025  Joe Testa <jtesta@positronsecurity.com>
 #
-# This script (adapted from the ssh-audit project) will set up a docker image with
-# multiple SSL/TLS servers.  They are each executed one at a time, and sslscan is run
-# against them.  The output of sslscan is compared against the expected output.  If
-# they match, the test passes; otherwise the test fails.
+# This script (adapted from the ssh-audit project) will set up a docker image with multiple SSL/TLS servers.  They are each executed one at a time, and sslscan is run against them.  The output of sslscan is compared against the expected output.  If they match, the test passes; otherwise the test fails.
 #
+# Running this script with no arguments causes it to build the docker image (if it doesn't yet exist), then run all tests.
 #
-# For debugging purposes, here is a cheat sheet for manually running the docker image:
-#
-# docker run -p 4443:443 --security-opt seccomp:unconfined -it sslscan-test:3 /bin/bash
-#
-
-#
-# Running this script with no arguments causes it to build the docker image (if it
-# doesn't yet exist), then run all tests.
-#
-# Running the script with a test number argument (i.e.: './docker_test.sh 2') will
-# run the docker image for test #2 only (in the background) and do nothing else.  This
-# allows the test itself to be debugged.
+# Running the script with a test number argument (i.e.: './docker_test.sh 2') will run the docker image for test #2 only (in the background) and do nothing else.  This allows the test itself to be debugged.
 #
 
 
-# This is the docker tag for the image.  If this tag doesn't exist, then we assume the
-# image is out of date, and generate a new one with this tag.
-IMAGE_VERSION=3
+# This is the docker tag for the image.  If this tag doesn't exist, then we assume the image is out of date, and generate a new one with this tag.
+IMAGE_VERSION=4
 
-# This is the name of our docker image.
+# This is the name of our test image.
 IMAGE_NAME=sslscan-test
 
 
@@ -44,187 +30,9 @@ GREENB="\033[1;32m"  # Green + bold
 all_passed=1
 
 
-# Number of processors on this system (used to compile parallel builds).
-NUM_PROCS=`/usr/bin/nproc --all 2> /dev/null`
-if [[ $NUM_PROCS == '' ]]; then
-    NUM_PROCS=4
-fi
-
-
 # Returns 0 if current docker image exists.
 function check_if_docker_image_exists {
     images=`docker image ls | grep -E "$IMAGE_NAME[[:space:]]+$IMAGE_VERSION"`
-}
-
-
-# Compile all version of GnuTLS.
-function compile_gnutls_all {
-    compile_gnutls '3.6.11.1'
-}
-
-
-# Compile all versions of OpenSSL.
-function compile_openssl_all {
-    compile_openssl '1.0.0'
-    compile_openssl '1.0.2'
-    compile_openssl '1.1.1'
-}
-
-
-# Compile a specific version of OpenSSL.
-function compile_openssl {
-    version=$1
-
-    git_tag=
-    compile_args=
-    precompile_command=
-    output_dir=
-    compile_num_procs=$NUM_PROCS
-    if [[ $version == '1.0.0' ]]; then
-	git_tag="OpenSSL_1_0_0-stable"
-	compile_args="enable-weak-ssl-ciphers enable-ssl2 zlib no-shared"
-	precompile_command="make depend"
-	output_dir="openssl_v1.0.0_dir"
-	compile_num_procs=1   # Compilation randomly fails when done in parallel.
-    elif [[ $version == '1.0.2' ]]; then
-	git_tag="OpenSSL_1_0_2-stable"
-	compile_args="enable-weak-ssl-ciphers enable-ssl2 zlib"
-	precompile_command="make depend"
-	output_dir="openssl_v1.0.2_dir"
-    elif [[ $version == '1.1.1' ]]; then
-	git_tag="OpenSSL_1_1_1-stable"
-	compile_args="enable-weak-ssl-ciphers no-shared zlib"
-	output_dir="openssl_v1.1.1_dir"
-    else
-	echo -e "${REDB}Error: OpenSSL v${version} is unknown!${CLR}"
-	exit 1
-    fi
-
-    # Download OpenSSL from github.
-    echo -e "\n${YELLOWB}Downloading OpenSSL v${version}...${CLR}\n"
-    git clone --depth 1 -b $git_tag https://github.com/openssl/openssl/ $output_dir
-
-    # Configure and compile it.
-    echo -e "\n\n${YELLOWB}Compiling OpenSSL v${version} with \"-j ${compile_num_procs}\"...${CLR}"
-    pushd $output_dir
-    ./config $compile_args
-    if [[ $precompile_command != '' ]]; then $precompile_command; fi
-    make -j $compile_num_procs
-
-    # Ensure that the 'openssl' command-line tool was built.
-    if [[ ! -f "apps/openssl" ]]; then
-	echo -e "${REDB}Error: compilation failed!  apps/openssl not found.${CLR}\n\nStrangely, sometimes OpenSSL v1.0.0 fails for no reason; simply running this script again and changing nothing fixes the problem.\n\n"
-	exit 1
-    fi
-
-    # Copy the 'openssl' app to the top-level docker building dir as, e.g. 'openssl_prog_v1.0.0'.  Then we can delete the source code directory and move on.
-    cp "apps/openssl" "../openssl_prog_v${version}"
-    popd
-
-    # Delete the source code directory now that we built the 'openssl' tool and moved it out.
-    rm -rf $output_dir
-    echo -e "\n\n${YELLOWB}Compilation of v${version} finished.${CLR}\n\n"
-}
-
-
-# Compile a specific version of GnuTLS.
-function compile_gnutls {
-    gnutls_version=$1
-
-    gnutls_url=
-    nettle_url=
-    gnutls_expected_sha256=
-    nettle_expected_sha256=
-    gnutls_filename=
-    nettle_filename=
-    gnutls_source_dir=
-    nettle_source_dir=
-    nettle_version=
-    compile_num_procs=$NUM_PROCS
-    compile_nettle=0
-    if [[ $gnutls_version == '3.6.11.1' ]]; then
-	gnutls_url=https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.11.1.tar.xz
-	gnutls_expected_sha256=fbba12f3db9a55dbf027e14111755817ec44b57eabec3e8089aac8ac6f533cf8
-	gnutls_filename=gnutls-3.6.11.1.tar.xz
-	gnutls_source_dir=gnutls-3.6.11.1
-	nettle_version=3.5.1
-	nettle_url=https://ftp.gnu.org/gnu/nettle/nettle-3.5.1.tar.gz
-	nettle_expected_sha256=75cca1998761b02e16f2db56da52992aef622bf55a3b45ec538bc2eedadc9419
-	nettle_filename=nettle-3.5.1.tar.gz
-	nettle_source_dir=nettle-3.5.1
-	compile_nettle=1
-    else
-	echo -e "${REDB}Error: GnuTLS v${gnutls_version} is unknown!${CLR}"
-	exit 1
-    fi
-
-    # Download GnuTLS.
-    echo -e "\n${YELLOWB}Downloading GnuTLS v${gnutls_version}...${CLR}\n"
-    wget $gnutls_url
-
-    # Download nettle.
-    echo -e "\n${YELLOWB}Downloading nettle library v${nettle_version}...${CLR}\n"
-    wget $nettle_url
-
-    # Check the SHA256 hashes.
-    gnutls_actual_sha256=`sha256sum ${gnutls_filename} | cut -f1 -d" "`
-    nettle_actual_sha256=`sha256sum ${nettle_filename} | cut -f1 -d" "`
-
-    if [[ ($gnutls_actual_sha256 != $gnutls_expected_sha256) || ($nettle_actual_sha256 != $nettle_expected_sha256) ]]; then
-	echo -e "${REDB}GnuTLS/nettle actual hashes differ from expected hashes! ${CLR}\n"
-	echo -e "\tGnuTLS expected hash: ${gnutls_expected_sha256}\n"
-	echo -e "\tGnuTLS actual hash:   ${gnutls_actual_sha256}\n"
-	echo -e "\tnettle expected hash: ${nettle_expected_sha256}\n"
-	echo -e "\tnettle actual hash:   ${nettle_actual_sha256}\n\n"
-	exit 1
-    else
-	echo -e "${GREEN}Hashes verified.${CLR}\n"
-    fi
-
-    tar xJf $gnutls_filename
-
-    if [[ $compile_nettle == 1 ]]; then
-	tar xzf $nettle_filename
-	mv $nettle_source_dir nettle
-
-	# Configure and compile nettle.
-	echo -e "\n\n${YELLOWB}Compiling nettle v${nettle_version} with \"-j ${compile_num_procs}\"...${CLR}"
-	pushd nettle
-	./configure && make -j $compile_num_procs
-
-	if [[ ! -f libnettle.so || ! -f libhogweed.so ]]; then
-	    echo -e "${REDB}Error: compilation failed!  libnettle.so and/or libhogweed.so not found.${CLR}"
-	    exit 1
-	fi
-	popd
-    fi
-
-    # Configure and compile GnuTLS.
-    echo -e "\n\n${YELLOWB}Compiling GnuTLS v${gnutls_version} with \"-j ${compile_num_procs}\"...${CLR}"
-    pushd $gnutls_source_dir
-    nettle_source_dir_abs=`readlink -m ../nettle`
-    nettle_parent_dir=`readlink -m ..`
-    NETTLE_CFLAGS=-I${nettle_parent_dir} NETTLE_LIBS="-L${nettle_source_dir_abs} -lnettle" HOGWEED_CFLAGS=-I${nettle_parent_dir} HOGWEED_LIBS="-L${nettle_source_dir_abs} -lhogweed" ./configure --with-included-libtasn1 --with-included-unistring --without-p11-kit --disable-guile
-    make CFLAGS=-I${nettle_parent_dir} LDFLAGS="-L${nettle_source_dir_abs} -lhogweed -lnettle" -j $compile_num_procs
-
-    # Ensure that the gnutls-serv and gnutls-cli tools were built
-    if [[ (! -f "src/.libs/gnutls-cli") || (! -f "src/.libs/gnutls-serv") ]]; then
-	echo -e "${REDB}Error: compilation failed!  gnutls-cli and/or gnutls-serv not found.${CLR}\n"
-	exit 1
-    fi
-
-    # Copy the gnutls-cli and gnutls-serv apps to the top-level docker building dir as, e.g. 'gnutls-cli-v3.6.11.1'.  Then we can delete the source code directory and move on.
-    cp "lib/.libs/libgnutls.so" "../libgnutls.so.30"
-    cp "src/.libs/gnutls-cli" "../gnutls-cli-v${gnutls_version}"
-    cp "src/.libs/gnutls-serv" "../gnutls-serv-v${gnutls_version}"
-    cp "${nettle_source_dir_abs}/libhogweed.so" "../libhogweed.so.5"
-    cp "${nettle_source_dir_abs}/libnettle.so" "../libnettle.so.7"
-    popd
-
-
-    # Delete the source code directory now that we built the tools and moved them out.
-    rm -rf ${gnutls_source_dir}
-    echo -e "\n\n${YELLOWB}Compilation of GnuTLS v${gnutls_version} finished.${CLR}\n\n"
 }
 
 
@@ -239,12 +47,6 @@ function create_docker_image {
     # Make the temp directory our working directory for the duration of the build
     # process.
     pushd $TMP_DIR > /dev/null
-
-    # Compile the versions of OpenSSL.
-    compile_openssl_all
-
-    # Compile the versions of GnuTLS.
-    compile_gnutls_all
 
     # Now build the docker image!
     echo -e "${YELLOWB}Creating docker image...$IMAGE_NAME:$IMAGE_VERSION ${CLR}"
@@ -327,17 +129,15 @@ function run_test_8 {
 }
 
 
-# Runs nginx with client certificate checking (signed by the CA in docker_test/ca_cert.pem).  sslscan will connect and make an HTTP request (--http).  The HTTP response code should be 200 to signify that the certificate was accepted.  Otherwise, nginx returns HTTP code 400 if no client certificates were presented.
+# OpenSSL v3.5.0, TLSv1.3 only, with all supported groups.
 function run_test_9 {
-    #run_test $1 '9' "/usr/sbin/nginx -c /etc/nginx/nginx_test9.conf" "--no-fallback --no-renegotiation --no-compression --no-heartbleed --certs=docker_test/cert_3072.crt --pk=docker_test/key_3072.pem --http"
-    echo "Test #9 skipped."
+    run_test $1 '9' "/openssl_v3.5.0/openssl s_server -accept 443 -key /etc/ssl/key_3072.pem -cert /etc/ssl/cert_3072.crt -tls1_3 -groups secp256r1:secp384r1:secp521r1:x25519:x448:brainpoolP256r1tls13:brainpoolP384r1tls13:brainpoolP512r1tls13:ffdhe2048:ffdhe3072:ffdhe4096:ffdhe6144:ffdhe8192:MLKEM512:MLKEM768:MLKEM1024:SecP256r1MLKEM768:X25519MLKEM768:SecP384r1MLKEM1024" ""
 }
 
 
-# Runs nginx with client certificate checking, just as above.  Except this time, we connect with no certificate.  The HTTP response code should be "400 Bad Request".
+# GnuTLS v3.8.9, TLSv1.3 only, with all supported groups.
 function run_test_10 {
-    #run_test $1 '10' "/usr/sbin/nginx -c /etc/nginx/nginx_test9.conf" "--no-fallback --no-renegotiation --no-compression --no-heartbleed --http"
-    echo "Test #10 skipped."
+    run_test $1 '10' "/gnutls-3.8.9/gnutls-serv -p 443 --x509certfile=/etc/ssl/cert_3072.crt --x509keyfile=/etc/ssl/key_3072.pem --priority=NORMAL:-VERS-TLS1.2:-VERS-TLS1.1:-VERS-TLS1.0:+GROUP-SECP192R1:+GROUP-SECP224R1:+GROUP-SECP256R1:+GROUP-SECP384R1:+GROUP-SECP521R1:+GROUP-X25519:+GROUP-GC256B:+GROUP-GC512A:+GROUP-X448:+GROUP-FFDHE2048:+GROUP-FFDHE3072:+GROUP-FFDHE4096:+GROUP-FFDHE6144:+GROUP-FFDHE8192" ""
 }
 
 
@@ -353,7 +153,7 @@ function run_test_12 {
 }
 
 
-# Default GnuTLS.
+# GnuTLS 3.6.11.1, default options.
 function run_test_13 {
     run_test $1 '13' "/gnutls-3.6.11.1/gnutls-serv -p 443 --x509certfile=/etc/ssl/cert_3072.crt --x509keyfile=/etc/ssl/key_3072.pem" ""
 }
@@ -389,9 +189,7 @@ function run_test_18 {
 }
 
 
-# Run a test.  Set the first argument to '1' to enable test debugging.
-# Second argument is the test number to run.  Third argument is the executable and
-# its args to be run inside the container..
+# Run a test.  Set the first argument to '1' to enable test debugging.  Second argument is the test number to run.  Third argument is the executable and its args to be run inside the container.
 function run_test {
     debug=$1
     test_number=$2
@@ -417,9 +215,7 @@ function run_test {
     # Wait 250ms to ensure that the services in the container are fully initialized.
     sleep 0.25
 
-    # Run sslscan and cut out the first two lines.  Those contain the version number
-    # and local version of OpenSSL, which can change over time (and when they do, this
-    # would break the test if they were left in).
+    # Run sslscan and cut out the first two lines.  Those contain the version number and local version of OpenSSL, which can change over time (and when they do, this would break the test if they were left in).
     ./sslscan $sslscan_additional_args 127.0.0.1:4443 | tail -n +3 > $test_result_stdout
     if [[ $? != 0 ]]; then
 	echo -e "${REDB}Failed to run sslscan! (exit code: $?)${CLR}"
@@ -454,8 +250,7 @@ function run_test {
 }
 
 
-# Instead of spinning up a docker instance, this will run a test using a host on the
-# public Internet.
+# Instead of spinning up a docker instance, this will run a test using a host on the public Internet.
 function run_test_internet {
     test_number=$1
     command=$2

--- a/docker_test/Dockerfile
+++ b/docker_test/Dockerfile
@@ -1,31 +1,38 @@
-FROM ubuntu:22.04
+# This is the Dockerfile to build the test image (which contains target servers to check sslscan's output against).
 
-# Copy OpenSSL's 'openssl' tools.
-COPY openssl_prog_v1.0.0 /openssl_v1.0.0/openssl
-COPY openssl_prog_v1.0.2 /openssl_v1.0.2/openssl
-COPY openssl_prog_v1.1.1 /openssl_v1.1.1/openssl
+FROM ubuntu:24.04 AS builder
 
-# Copy GnuTLS client & server tools, along with their required libraries.
-COPY gnutls-cli-v3.6.11.1 /gnutls-3.6.11.1/gnutls-cli
-COPY gnutls-serv-v3.6.11.1 /gnutls-3.6.11.1/gnutls-serv
-COPY libhogweed.so.5 /usr/lib/
-COPY libnettle.so.7 /usr/lib/
-COPY libgnutls.so.30 /usr/lib/x86_64-linux-gnu/
+COPY build_test_apps.sh /build/build_test_apps.sh
+
+# Update base image and install prerequisites for building.
+RUN apt update; apt install -y build-essential zlib1g zlib1g-dev nettle-dev git wget m4 pkg-config
+
+# Build all applications.
+RUN /bin/bash /build/build_test_apps.sh
+
+
+# Starting from a fresh image, copy over the built applications from the prior stage.
+FROM ubuntu:24.04
+
+COPY --from=builder /build/libhogweed.so.5 /usr/lib/libhogweed.so.5
+COPY --from=builder /build/libnettle.so.7 /usr/lib/libnettle.so.7
+
+COPY --from=builder /build/gnutls-cli-v3.6.11.1 /gnutls-3.6.11.1/gnutls-cli
+COPY --from=builder /build/gnutls-serv-v3.6.11.1 /gnutls-3.6.11.1/gnutls-serv
+
+COPY --from=builder /build/gnutls-cli-v3.8.9 /gnutls-3.8.9/gnutls-cli
+COPY --from=builder /build/gnutls-serv-v3.8.9 /gnutls-3.8.9/gnutls-serv
+
+COPY --from=builder /build/openssl_prog_v1.0.0 /openssl_v1.0.0/openssl
+COPY --from=builder /build/openssl_prog_v1.0.2 /openssl_v1.0.2/openssl
+COPY --from=builder /build/openssl_prog_v1.1.1 /openssl_v1.1.1/openssl
+COPY --from=builder /build/openssl_prog_v3.5.0 /openssl_v3.5.0/openssl
 
 # Copy certificates, keys, and DH parameters.
 COPY *.pem /etc/ssl/
 COPY *.crt /etc/ssl/
 
-# Copy nginx site configurations & modules.
-COPY nginx_site_client_cert_required /etc/nginx/sites-available/
-COPY nginx_test9.conf /etc/nginx/
-
-# Install nginx for some tests.
-# Install strace for potential debugging, and rsyslog to enable system log gathering.
-RUN apt update 2> /dev/null
-RUN apt install -y nginx strace rsyslog ca-certificates 2> /dev/null
-RUN apt clean 2> /dev/null
-
-RUN update-ca-certificates
+# This config file seems to tell GnuTLS to not allow TLSv1.0 or TLSv1.1, which we need for testing.
+RUN rm -f /etc/gnutls/config
 
 EXPOSE 443

--- a/docker_test/build_test_apps.sh
+++ b/docker_test/build_test_apps.sh
@@ -1,0 +1,241 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2019-2025  Joe Testa <jtesta@positronsecurity.com>
+#
+# This script, designed to run inside a container, will build several versions of OpenSSL and GnuTLS so that testing can be done against them.
+#
+
+
+# Terminal colors.
+CLR="\033[0m"
+RED="\033[0;31m"
+GREEN="\033[0;32m"
+REDB="\033[1;31m"    # Red + bold
+YELLOWB="\033[1;33m" # Yellow + bold
+GREENB="\033[1;32m"  # Green + bold
+
+
+# Number of processors on this system (used to compile parallel builds).
+NUM_PROCS=$(/usr/bin/nproc --all)
+if [[ "${NUM_PROCS}" == "" ]]; then
+    NUM_PROCS=4
+fi
+
+
+# Compile all version of GnuTLS.
+function compile_gnutls_all {
+    compile_gnutls '3.6.11.1'
+    compile_gnutls '3.8.9'
+}
+
+# Compile all versions of OpenSSL.
+function compile_openssl_all {
+    compile_openssl '1.0.0'
+    compile_openssl '1.0.2'
+    compile_openssl '1.1.1'
+    compile_openssl '3.5.0'
+}
+
+# Compile a specific version of OpenSSL.
+function compile_openssl {
+    version=$1
+
+    git_tag=
+    compile_args=
+    precompile_command=
+    output_dir=
+    compile_num_procs=${NUM_PROCS}
+    if [[ $version == '1.0.0' ]]; then
+	git_tag="OpenSSL_1_0_0-stable"
+	compile_args="enable-weak-ssl-ciphers enable-ssl2 zlib no-shared"
+	precompile_command="make depend"
+	output_dir="openssl_v1.0.0_dir"
+	compile_num_procs=1   # Compilation randomly fails when done in parallel.
+    elif [[ $version == '1.0.2' ]]; then
+	git_tag="OpenSSL_1_0_2-stable"
+	compile_args="enable-weak-ssl-ciphers enable-ssl2 zlib"
+	precompile_command="make depend"
+	output_dir="openssl_v1.0.2_dir"
+    elif [[ $version == '1.1.1' ]]; then
+	git_tag="OpenSSL_1_1_1-stable"
+	compile_args="enable-weak-ssl-ciphers no-shared zlib"
+	output_dir="openssl_v1.1.1_dir"
+    elif [[ $version == '3.5.0' ]]; then
+	git_tag="openssl-3.5.0"
+	compile_args="enable-weak-ssl-ciphers no-shared zlib"
+	output_dir="openssl_v3.5.0_dir"
+    else
+	echo -e "${REDB}Error: OpenSSL v${version} is unknown!${CLR}"
+	exit 1
+    fi
+
+    # Download OpenSSL from github.
+    echo -e "\n${YELLOWB}Downloading OpenSSL v${version}...${CLR}\n"
+    git clone --depth 1 -b ${git_tag} https://github.com/openssl/openssl/ ${output_dir}
+
+    # Configure and compile it.
+    echo -e "\n\n${YELLOWB}Compiling OpenSSL v${version} with \"-j ${compile_num_procs}\"...${CLR}"
+    pushd ${output_dir}
+    ./config ${compile_args}
+    if [[ ${precompile_command} != '' ]]; then ${precompile_command}; fi
+    make -j ${compile_num_procs}
+
+    # Ensure that the 'openssl' command-line tool was built.
+    if [[ ! -f "apps/openssl" ]]; then
+	echo -e "${REDB}Error: compilation failed!  apps/openssl not found.${CLR}\n\nStrangely, sometimes OpenSSL v1.0.0 fails for no reason; simply running this script again and changing nothing fixes the problem.\n\n"
+	exit 1
+    fi
+
+    # Copy the 'openssl' app to the top-level docker building dir as, e.g. 'openssl_prog_v1.0.0'.  Then we can delete the source code directory and move on.
+    cp "apps/openssl" "/build/openssl_prog_v${version}"
+    popd
+
+    # Delete the source code directory now that we built the 'openssl' tool and moved it out.
+    rm -rf ${output_dir}
+    echo -e "\n\n${YELLOWB}Compilation of v${version} finished.${CLR}\n\n"
+}
+
+# Compile a specific version of GnuTLS.
+function compile_gnutls {
+    gnutls_version=$1
+
+    gnutls_url=
+    nettle_url=
+    gnutls_expected_sha256=
+    nettle_expected_sha256=
+    gnutls_filename=
+    nettle_filename=
+    gnutls_source_dir=
+    nettle_source_dir=
+    nettle_version=
+    compile_num_procs=${NUM_PROCS}
+    compile_nettle=0
+    if [[ "${gnutls_version}" == "3.6.11.1" ]]; then
+	gnutls_url=https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.11.1.tar.xz
+	gnutls_expected_sha256=fbba12f3db9a55dbf027e14111755817ec44b57eabec3e8089aac8ac6f533cf8
+	gnutls_filename=gnutls-3.6.11.1.tar.xz
+	gnutls_source_dir=gnutls-3.6.11.1
+	nettle_version=3.5.1
+	nettle_url=https://ftp.gnu.org/gnu/nettle/nettle-3.5.1.tar.gz
+	nettle_expected_sha256=75cca1998761b02e16f2db56da52992aef622bf55a3b45ec538bc2eedadc9419
+	nettle_filename=nettle-3.5.1.tar.gz
+	nettle_source_dir=nettle-3.5.1
+	compile_nettle=1
+    elif [[ "${gnutls_version}" == "3.8.9" ]]; then
+        echo "Using platform's nettle library."
+        gnutls_url=https://www.gnupg.org/ftp/gcrypt/gnutls/v3.8/gnutls-3.8.9.tar.xz
+	gnutls_expected_sha256=69e113d802d1670c4d5ac1b99040b1f2d5c7c05daec5003813c049b5184820ed
+	gnutls_filename=gnutls-3.8.9.tar.xz
+	gnutls_source_dir=gnutls-3.8.9
+    else
+	echo -e "${REDB}Error: GnuTLS v${gnutls_version} is unknown!${CLR}"
+	exit 1
+    fi
+
+    # Download GnuTLS.
+    echo -e "\n${YELLOWB}Downloading GnuTLS v${gnutls_version}...${CLR}\n"
+    wget ${gnutls_url}
+
+    # Check the SHA256 hash.
+    gnutls_actual_sha256=$(sha256sum ${gnutls_filename} | cut -f1 -d" ")
+
+    if [[ "${gnutls_actual_sha256}" != "${gnutls_expected_sha256}" ]]; then
+        echo -e "${REDB}GnuTLS/nettle actual hashes differ from expected hashes! ${CLR}\n"
+        echo -e "\tGnuTLS expected hash: ${gnutls_expected_sha256}\n"
+        echo -e "\tGnuTLS actual hash:   ${gnutls_actual_sha256}\n"
+
+        exit 1
+    fi
+
+    echo -e "${GREEN}GnuTLS hash verified.${CLR}\n"
+
+    # Uncompress the archive.
+    tar xJf ${gnutls_filename}
+
+    # Some versions require us to compile a version of nettle ourselves.  For others, the system package version works perfectly.
+    if [[ "${compile_nettle}" == 1 ]]; then
+
+        # Download nettle.
+        echo -e "\n${YELLOWB}Downloading nettle library v${nettle_version}...${CLR}\n"
+        wget ${nettle_url}
+
+        # Ensure the hash of the package is what we expect.
+        nettle_actual_sha256=$(sha256sum ${nettle_filename} | cut -f1 -d" ")
+        if [[ "${nettle_actual_sha256}" != "${nettle_expected_sha256}" ]]; then
+            echo -e "${REDB}nettle actual hashes differ from expected hashes! ${CLR}\n"
+            echo -e "\tnettle expected hash: ${nettle_expected_sha256}\n"
+            echo -e "\tnettle actual hash:   ${nettle_actual_sha256}\n\n"
+            exit 1
+        fi
+
+        echo -e "${GREEN}Nettle hash verified.${CLR}\n"
+
+        tar xzf ${nettle_filename}
+        mv ${nettle_source_dir} nettle
+
+        # Configure and compile nettle.
+        echo -e "\n\n${YELLOWB}Compiling nettle v${nettle_version} with \"-j ${compile_num_procs}\"...${CLR}"
+        pushd nettle
+        ./configure && make -j ${compile_num_procs} CFLAGS="-fPIC"
+
+        if [[ ! -f libnettle.so || ! -f libhogweed.so ]]; then
+            echo -e "${REDB}Error: compilation failed!  libnettle.so and/or libhogweed.so not found.${CLR}"
+            exit 1
+        fi
+        popd
+    fi
+
+    # Configure and compile GnuTLS.
+    echo -e "\n\n${YELLOWB}Compiling GnuTLS v${gnutls_version} with \"-j ${compile_num_procs}\"...${CLR}"
+    pushd ${gnutls_source_dir}
+
+    # This seems to be an existing system file which disables support for TLSv1.0 and v1.1!
+    rm -f /etc/gnutls/config
+
+    if [[ "${compile_nettle}" == 1 ]]; then
+        nettle_source_dir_abs=$(readlink -f ../nettle)
+        nettle_parent_dir=$(readlink -f ..)
+        NETTLE_CFLAGS=-I${nettle_parent_dir} NETTLE_LIBS="-L${nettle_source_dir_abs} -lnettle" HOGWEED_CFLAGS=-I${nettle_parent_dir} HOGWEED_LIBS="-L${nettle_source_dir_abs} -lhogweed" ./configure --with-included-libtasn1 --with-included-unistring --without-p11-kit --disable-guile
+
+        make CFLAGS="-static -fPIC -I${nettle_parent_dir}" LDFLAGS="-L${nettle_source_dir_abs} -lhogweed -lnettle" -j ${compile_num_procs}
+    else
+        ./configure --with-included-libtasn1 --with-included-unistring --without-p11-kit
+        make CFLAGS="-static -fPIC" -j ${compile_num_procs}
+    fi
+
+    # Ensure that the gnutls-serv and gnutls-cli tools were built
+    if [ ! -f "src/gnutls-cli" ] || [ ! -f "src/gnutls-serv" ]; then
+	echo -e "${REDB}Error: compilation failed!  gnutls-cli and/or gnutls-serv not found.${CLR}\n"
+	exit 1
+    fi
+
+    # Copy the gnutls-cli and gnutls-serv apps to the top-level docker building dir as, e.g. 'gnutls-cli-v3.6.11.1'.  Then we can delete the source code directory and move on.
+    cp "src/gnutls-cli" "/build/gnutls-cli-v${gnutls_version}"
+    cp "src/gnutls-serv" "/build/gnutls-serv-v${gnutls_version}"
+
+    if [[ "${compile_nettle}" == 1 ]]; then
+        cp "${nettle_source_dir_abs}/libhogweed.so" "/build/libhogweed.so.5"
+        cp "${nettle_source_dir_abs}/libnettle.so" "/build/libnettle.so.7"
+    fi
+    popd
+
+    # Delete the source code directory now that we built the tools and moved them out.
+    rm -rf ${gnutls_source_dir}
+    echo -e "\n\n${YELLOWB}Compilation of GnuTLS v${gnutls_version} finished.${CLR}\n\n"
+}
+
+
+echo -e "\n\nBuilding with ${GREENB}${NUM_PROCS}${CLR} threads.\n"
+
+cd /build
+compile_openssl_all
+compile_gnutls_all
+
+# Strip all the programs of debugging symbols in order to cut down on storage space.
+strip /build/openssl_prog*
+strip /build/gnutls-cli*
+strip /build/gnutls-serv*
+strip /build/lib*
+
+echo -e "\n\n${GREENB}Done compiling applications!${CLR}\n"

--- a/docker_test/expected_output/test_1.txt
+++ b/docker_test/expected_output/test_1.txt
@@ -34,66 +34,66 @@ Accepted  TLSv1.2  [32m256[0m bits  ECDHE-RSA-AES256-SHA384       Curve P-256 
 Accepted  TLSv1.2  [32m256[0m bits  DHE-RSA-AES256-SHA256         DHE 2048 bits
 Accepted  TLSv1.2  [32m128[0m bits  ECDHE-RSA-AES128-SHA256       Curve P-256 DHE 256
 Accepted  TLSv1.2  [32m128[0m bits  DHE-RSA-AES128-SHA256         DHE 2048 bits
-Accepted  TLSv1.2  [32m256[0m bits  ECDHE-RSA-AES256-SHA          Curve P-256 DHE 256
-Accepted  TLSv1.2  [32m256[0m bits  DHE-RSA-AES256-SHA            DHE 2048 bits
-Accepted  TLSv1.2  [32m256[0m bits  DHE-RSA-CAMELLIA256-SHA       DHE 2048 bits
-Accepted  TLSv1.2  [32m128[0m bits  ECDHE-RSA-AES128-SHA          Curve P-256 DHE 256
-Accepted  TLSv1.2  [32m128[0m bits  DHE-RSA-AES128-SHA            DHE 2048 bits
-Accepted  TLSv1.2  [32m128[0m bits  DHE-RSA-CAMELLIA128-SHA       DHE 2048 bits
-Accepted  TLSv1.2  [32m112[0m bits  [33mECDHE-RSA-DES-CBC3-SHA       [0m Curve P-256 DHE 256
-Accepted  TLSv1.2  [32m112[0m bits  [33mDHE-RSA-DES-CBC3-SHA         [0m DHE 2048 bits
+Accepted  TLSv1.2  [32m256[0m bits  [33mECDHE-RSA-AES256-SHA         [0m Curve P-256 DHE 256
+Accepted  TLSv1.2  [32m256[0m bits  [33mDHE-RSA-AES256-SHA           [0m DHE 2048 bits
+Accepted  TLSv1.2  [32m256[0m bits  [33mDHE-RSA-CAMELLIA256-SHA      [0m DHE 2048 bits
+Accepted  TLSv1.2  [32m128[0m bits  [33mECDHE-RSA-AES128-SHA         [0m Curve P-256 DHE 256
+Accepted  TLSv1.2  [32m128[0m bits  [33mDHE-RSA-AES128-SHA           [0m DHE 2048 bits
+Accepted  TLSv1.2  [32m128[0m bits  [33mDHE-RSA-CAMELLIA128-SHA      [0m DHE 2048 bits
+Accepted  TLSv1.2  [33m112[0m bits  [33mECDHE-RSA-DES-CBC3-SHA       [0m Curve P-256 DHE 256
+Accepted  TLSv1.2  [33m112[0m bits  [33mDHE-RSA-DES-CBC3-SHA         [0m DHE 2048 bits
 Accepted  TLSv1.2  [32m256[0m bits  AES256-GCM-SHA384            
 Accepted  TLSv1.2  [32m128[0m bits  AES128-GCM-SHA256            
 Accepted  TLSv1.2  [32m256[0m bits  AES256-SHA256                
 Accepted  TLSv1.2  [32m128[0m bits  AES128-SHA256                
-Accepted  TLSv1.2  [32m256[0m bits  AES256-SHA                   
-Accepted  TLSv1.2  [32m256[0m bits  CAMELLIA256-SHA              
-Accepted  TLSv1.2  [32m128[0m bits  AES128-SHA                   
-Accepted  TLSv1.2  [32m128[0m bits  CAMELLIA128-SHA              
-Accepted  TLSv1.2  [32m112[0m bits  [33mDES-CBC3-SHA                 [0m
-Accepted  TLSv1.2  [32m128[0m bits  [33mTLS_RSA_WITH_RC4_128_MD5     [0m
+Accepted  TLSv1.2  [32m256[0m bits  [33mAES256-SHA                   [0m
+Accepted  TLSv1.2  [32m256[0m bits  [33mCAMELLIA256-SHA              [0m
+Accepted  TLSv1.2  [32m128[0m bits  [33mAES128-SHA                   [0m
+Accepted  TLSv1.2  [32m128[0m bits  [33mCAMELLIA128-SHA              [0m
+Accepted  TLSv1.2  [33m112[0m bits  [33mDES-CBC3-SHA                 [0m
+Accepted  TLSv1.2  [32m128[0m bits  [31mTLS_RSA_WITH_RC4_128_MD5     [0m
 Accepted  TLSv1.2  [32m128[0m bits  [33mTLS_RSA_WITH_RC4_128_SHA     [0m
-Accepted  TLSv1.2  [32m128[0m bits  TLS_RSA_WITH_IDEA_CBC_SHA    
-Accepted  TLSv1.2  [32m128[0m bits  TLS_RSA_WITH_SEED_CBC_SHA    
-Accepted  TLSv1.2  [32m128[0m bits  TLS_DHE_RSA_WITH_SEED_CBC_SHA
+Accepted  TLSv1.2  [32m128[0m bits  [33mTLS_RSA_WITH_IDEA_CBC_SHA    [0m
+Accepted  TLSv1.2  [32m128[0m bits  [33mTLS_RSA_WITH_SEED_CBC_SHA    [0m
+Accepted  TLSv1.2  [32m128[0m bits  [33mTLS_DHE_RSA_WITH_SEED_CBC_SHA[0m
 Accepted  TLSv1.2  [32m128[0m bits  [33mTLS_ECDHE_RSA_WITH_RC4_128_SHA[0m
-[32mPreferred[0m [33mTLSv1.1[0m  [32m256[0m bits  ECDHE-RSA-AES256-SHA          Curve P-256 DHE 256
-Accepted  [33mTLSv1.1[0m  [32m256[0m bits  DHE-RSA-AES256-SHA            DHE 2048 bits
-Accepted  [33mTLSv1.1[0m  [32m256[0m bits  DHE-RSA-CAMELLIA256-SHA       DHE 2048 bits
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  ECDHE-RSA-AES128-SHA          Curve P-256 DHE 256
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  DHE-RSA-AES128-SHA            DHE 2048 bits
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  DHE-RSA-CAMELLIA128-SHA       DHE 2048 bits
-Accepted  [33mTLSv1.1[0m  [32m112[0m bits  [33mECDHE-RSA-DES-CBC3-SHA       [0m Curve P-256 DHE 256
-Accepted  [33mTLSv1.1[0m  [32m112[0m bits  [33mDHE-RSA-DES-CBC3-SHA         [0m DHE 2048 bits
-Accepted  [33mTLSv1.1[0m  [32m256[0m bits  AES256-SHA                   
-Accepted  [33mTLSv1.1[0m  [32m256[0m bits  CAMELLIA256-SHA              
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  AES128-SHA                   
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  CAMELLIA128-SHA              
-Accepted  [33mTLSv1.1[0m  [32m112[0m bits  [33mDES-CBC3-SHA                 [0m
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mTLS_RSA_WITH_RC4_128_MD5     [0m
+[32mPreferred[0m [33mTLSv1.1[0m  [32m256[0m bits  [33mECDHE-RSA-AES256-SHA         [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.1[0m  [32m256[0m bits  [33mDHE-RSA-AES256-SHA           [0m DHE 2048 bits
+Accepted  [33mTLSv1.1[0m  [32m256[0m bits  [33mDHE-RSA-CAMELLIA256-SHA      [0m DHE 2048 bits
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mECDHE-RSA-AES128-SHA         [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mDHE-RSA-AES128-SHA           [0m DHE 2048 bits
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mDHE-RSA-CAMELLIA128-SHA      [0m DHE 2048 bits
+Accepted  [33mTLSv1.1[0m  [33m112[0m bits  [33mECDHE-RSA-DES-CBC3-SHA       [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.1[0m  [33m112[0m bits  [33mDHE-RSA-DES-CBC3-SHA         [0m DHE 2048 bits
+Accepted  [33mTLSv1.1[0m  [32m256[0m bits  [33mAES256-SHA                   [0m
+Accepted  [33mTLSv1.1[0m  [32m256[0m bits  [33mCAMELLIA256-SHA              [0m
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mAES128-SHA                   [0m
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mCAMELLIA128-SHA              [0m
+Accepted  [33mTLSv1.1[0m  [33m112[0m bits  [33mDES-CBC3-SHA                 [0m
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [31mTLS_RSA_WITH_RC4_128_MD5     [0m
 Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mTLS_RSA_WITH_RC4_128_SHA     [0m
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  TLS_RSA_WITH_IDEA_CBC_SHA    
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  TLS_RSA_WITH_SEED_CBC_SHA    
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  TLS_DHE_RSA_WITH_SEED_CBC_SHA
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mTLS_RSA_WITH_IDEA_CBC_SHA    [0m
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mTLS_RSA_WITH_SEED_CBC_SHA    [0m
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mTLS_DHE_RSA_WITH_SEED_CBC_SHA[0m
 Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mTLS_ECDHE_RSA_WITH_RC4_128_SHA[0m
-[32mPreferred[0m [33mTLSv1.0[0m  [32m256[0m bits  ECDHE-RSA-AES256-SHA          Curve P-256 DHE 256
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  DHE-RSA-AES256-SHA            DHE 2048 bits
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  DHE-RSA-CAMELLIA256-SHA       DHE 2048 bits
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  ECDHE-RSA-AES128-SHA          Curve P-256 DHE 256
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  DHE-RSA-AES128-SHA            DHE 2048 bits
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  DHE-RSA-CAMELLIA128-SHA       DHE 2048 bits
-Accepted  [33mTLSv1.0[0m  [32m112[0m bits  [33mECDHE-RSA-DES-CBC3-SHA       [0m Curve P-256 DHE 256
-Accepted  [33mTLSv1.0[0m  [32m112[0m bits  [33mDHE-RSA-DES-CBC3-SHA         [0m DHE 2048 bits
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  AES256-SHA                   
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  CAMELLIA256-SHA              
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  AES128-SHA                   
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  CAMELLIA128-SHA              
-Accepted  [33mTLSv1.0[0m  [32m112[0m bits  [33mDES-CBC3-SHA                 [0m
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_RSA_WITH_RC4_128_MD5     [0m
+[32mPreferred[0m [33mTLSv1.0[0m  [32m256[0m bits  [33mECDHE-RSA-AES256-SHA         [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mDHE-RSA-AES256-SHA           [0m DHE 2048 bits
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mDHE-RSA-CAMELLIA256-SHA      [0m DHE 2048 bits
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mECDHE-RSA-AES128-SHA         [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mDHE-RSA-AES128-SHA           [0m DHE 2048 bits
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mDHE-RSA-CAMELLIA128-SHA      [0m DHE 2048 bits
+Accepted  [33mTLSv1.0[0m  [33m112[0m bits  [33mECDHE-RSA-DES-CBC3-SHA       [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.0[0m  [33m112[0m bits  [33mDHE-RSA-DES-CBC3-SHA         [0m DHE 2048 bits
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mAES256-SHA                   [0m
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mCAMELLIA256-SHA              [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mAES128-SHA                   [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mCAMELLIA128-SHA              [0m
+Accepted  [33mTLSv1.0[0m  [33m112[0m bits  [33mDES-CBC3-SHA                 [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [31mTLS_RSA_WITH_RC4_128_MD5     [0m
 Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_RSA_WITH_RC4_128_SHA     [0m
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  TLS_RSA_WITH_IDEA_CBC_SHA    
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  TLS_RSA_WITH_SEED_CBC_SHA    
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  TLS_DHE_RSA_WITH_SEED_CBC_SHA
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_RSA_WITH_IDEA_CBC_SHA    [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_RSA_WITH_SEED_CBC_SHA    [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_DHE_RSA_WITH_SEED_CBC_SHA[0m
 Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_ECDHE_RSA_WITH_RC4_128_SHA[0m
 
   [1;34mServer Key Exchange Group(s):[0m

--- a/docker_test/expected_output/test_10.txt
+++ b/docker_test/expected_output/test_10.txt
@@ -8,17 +8,46 @@ SSLv2     [32mdisabled[0m
 SSLv3     [32mdisabled[0m
 TLSv1.0   [32mdisabled[0m
 TLSv1.1   [32mdisabled[0m
-TLSv1.2   enabled
-TLSv1.3   [33mdisabled[0m
+TLSv1.2   disabled
+TLSv1.3   [32menabled[0m
+
+  [1;34mTLS Fallback SCSV:[0m
+Server [32msupports[0m TLS Fallback SCSV
+
+  [1;34mTLS renegotiation:[0m
+Session renegotiation [32mnot supported[0m
+
+  [1;34mTLS Compression:[0m
+Compression [32mdisabled[0m
+
+  [1;34mHeartbleed:[0m
+TLSv1.3 [32mnot vulnerable[0m to heartbleed
 
   [1;34mSupported Server Cipher(s):[0m
-[32mPreferred[0m 400 Bad Request  TLSv1.2  [32m256[0m bits  [32mECDHE-RSA-CHACHA20-POLY1305  [0m Curve [32m25519[0m DHE 253
+[32mPreferred[0m [32mTLSv1.3[0m  [32m128[0m bits  [32mTLS_AES_128_GCM_SHA256       [0m Curve [32m25519[0m DHE 253
+Accepted  [32mTLSv1.3[0m  [32m256[0m bits  [32mTLS_AES_256_GCM_SHA384       [0m Curve [32m25519[0m DHE 253
+Accepted  [32mTLSv1.3[0m  [32m256[0m bits  [32mTLS_CHACHA20_POLY1305_SHA256 [0m Curve [32m25519[0m DHE 253
+Accepted  [32mTLSv1.3[0m  [32m128[0m bits  TLS_AES_128_CCM_SHA256        Curve [32m25519[0m DHE 253
+
+  [1;34mServer Key Exchange Group(s):[0m
+TLSv1.3  [31m96[0m bits  [31msecp192r1[0m
+TLSv1.3  [32m112[0m bits  secp224r1[0m
+TLSv1.3  [32m128[0m bits  secp256r1 (NIST P-256)[0m
+TLSv1.3  [32m192[0m bits  secp384r1 (NIST P-384)[0m
+TLSv1.3  [32m260[0m bits  secp521r1 (NIST P-521)[0m
+TLSv1.3  [32m128[0m bits  [32mx25519[0m
+TLSv1.3  [32m224[0m bits  [32mx448[0m
+TLSv1.3  [32m112[0m bits  ffdhe2048[0m
+TLSv1.3  [32m128[0m bits  ffdhe3072[0m
+TLSv1.3  [32m150[0m bits  ffdhe4096[0m
+TLSv1.3  [32m175[0m bits  ffdhe6144[0m
+TLSv1.3  [32m192[0m bits  ffdhe8192[0m
 
   [1;34mSSL Certificate:[0m
 Signature Algorithm: [32msha256WithRSAEncryption[0m
-RSA Key Strength:    3072
+RSA Key Strength:    [32m3072[0m
 
 Subject:  lmgtfy.com
-Issuer:   /C=XX/ST=Nowhere in particular/L=Nowhere
+Issuer:   /C=XX/ST=Nowhere in particular/L=Nowhere[0m
 Not valid before: [32mDec  3 04:07:43 2019 GMT[0m
 Not valid after:  [32mDec  3 04:07:43 2029 GMT[0m

--- a/docker_test/expected_output/test_12.txt
+++ b/docker_test/expected_output/test_12.txt
@@ -24,26 +24,26 @@ Compression [31menabled[0m (CRIME)
 TLSv1.0 [32mnot vulnerable[0m to heartbleed
 
   [1;34mSupported Server Cipher(s):[0m
-[32mPreferred[0m [33mTLSv1.0[0m  [32m256[0m bits  ECDHE-RSA-AES256-SHA          Curve P-256 DHE 256
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  DHE-RSA-AES256-SHA            DHE [31m512[0m bits
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  DHE-RSA-CAMELLIA256-SHA       DHE [31m512[0m bits
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  ECDHE-RSA-AES128-SHA          Curve P-256 DHE 256
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  DHE-RSA-AES128-SHA            DHE [31m512[0m bits
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  DHE-RSA-CAMELLIA128-SHA       DHE [31m512[0m bits
-Accepted  [33mTLSv1.0[0m  [32m112[0m bits  [33mECDHE-RSA-DES-CBC3-SHA       [0m Curve P-256 DHE 256
-Accepted  [33mTLSv1.0[0m  [32m112[0m bits  [33mDHE-RSA-DES-CBC3-SHA         [0m DHE [31m512[0m bits
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  AES256-SHA                   
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  CAMELLIA256-SHA              
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  AES128-SHA                   
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  CAMELLIA128-SHA              
-Accepted  [33mTLSv1.0[0m  [32m112[0m bits  [33mDES-CBC3-SHA                 [0m
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_RSA_WITH_RC4_128_MD5     [0m
+[32mPreferred[0m [33mTLSv1.0[0m  [32m256[0m bits  [33mECDHE-RSA-AES256-SHA         [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mDHE-RSA-AES256-SHA           [0m DHE [31m512[0m bits
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mDHE-RSA-CAMELLIA256-SHA      [0m DHE [31m512[0m bits
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mECDHE-RSA-AES128-SHA         [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mDHE-RSA-AES128-SHA           [0m DHE [31m512[0m bits
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mDHE-RSA-CAMELLIA128-SHA      [0m DHE [31m512[0m bits
+Accepted  [33mTLSv1.0[0m  [33m112[0m bits  [33mECDHE-RSA-DES-CBC3-SHA       [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.0[0m  [33m112[0m bits  [33mDHE-RSA-DES-CBC3-SHA         [0m DHE [31m512[0m bits
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mAES256-SHA                   [0m
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mCAMELLIA256-SHA              [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mAES128-SHA                   [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mCAMELLIA128-SHA              [0m
+Accepted  [33mTLSv1.0[0m  [33m112[0m bits  [33mDES-CBC3-SHA                 [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [31mTLS_RSA_WITH_RC4_128_MD5     [0m
 Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_RSA_WITH_RC4_128_SHA     [0m
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  TLS_RSA_WITH_IDEA_CBC_SHA    
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_RSA_WITH_IDEA_CBC_SHA    [0m
 Accepted  [33mTLSv1.0[0m  [31m56[0m bits   [33mTLS_RSA_WITH_DES_CBC_SHA     [0m
 Accepted  [33mTLSv1.0[0m  [31m56[0m bits   [33mTLS_DHE_RSA_WITH_DES_CBC_SHA [0m
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  TLS_RSA_WITH_SEED_CBC_SHA    
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  TLS_DHE_RSA_WITH_SEED_CBC_SHA
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_RSA_WITH_SEED_CBC_SHA    [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_DHE_RSA_WITH_SEED_CBC_SHA[0m
 Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_ECDHE_RSA_WITH_RC4_128_SHA[0m
 
   [1;34mServer Key Exchange Group(s):[0m

--- a/docker_test/expected_output/test_13.txt
+++ b/docker_test/expected_output/test_13.txt
@@ -39,28 +39,28 @@ Accepted  TLSv1.2  [32m256[0m bits  DHE-RSA-AES256-CCM            DHE 2048 bit
 Accepted  TLSv1.2  [32m128[0m bits  [32mECDHE-RSA-AES128-GCM-SHA256  [0m Curve [32m25519[0m DHE 253
 Accepted  TLSv1.2  [32m128[0m bits  [32mDHE-RSA-AES128-GCM-SHA256    [0m DHE 2048 bits
 Accepted  TLSv1.2  [32m128[0m bits  DHE-RSA-AES128-CCM            DHE 2048 bits
-Accepted  TLSv1.2  [32m256[0m bits  ECDHE-RSA-AES256-SHA          Curve [32m25519[0m DHE 253
-Accepted  TLSv1.2  [32m256[0m bits  DHE-RSA-AES256-SHA            DHE 2048 bits
-Accepted  TLSv1.2  [32m128[0m bits  ECDHE-RSA-AES128-SHA          Curve [32m25519[0m DHE 253
-Accepted  TLSv1.2  [32m128[0m bits  DHE-RSA-AES128-SHA            DHE 2048 bits
+Accepted  TLSv1.2  [32m256[0m bits  [33mECDHE-RSA-AES256-SHA         [0m Curve [32m25519[0m DHE 253
+Accepted  TLSv1.2  [32m256[0m bits  [33mDHE-RSA-AES256-SHA           [0m DHE 2048 bits
+Accepted  TLSv1.2  [32m128[0m bits  [33mECDHE-RSA-AES128-SHA         [0m Curve [32m25519[0m DHE 253
+Accepted  TLSv1.2  [32m128[0m bits  [33mDHE-RSA-AES128-SHA           [0m DHE 2048 bits
 Accepted  TLSv1.2  [32m256[0m bits  AES256-GCM-SHA384            
 Accepted  TLSv1.2  [32m256[0m bits  AES256-CCM                   
 Accepted  TLSv1.2  [32m128[0m bits  AES128-GCM-SHA256            
 Accepted  TLSv1.2  [32m128[0m bits  AES128-CCM                   
-Accepted  TLSv1.2  [32m256[0m bits  AES256-SHA                   
-Accepted  TLSv1.2  [32m128[0m bits  AES128-SHA                   
-[32mPreferred[0m [33mTLSv1.1[0m  [32m256[0m bits  ECDHE-RSA-AES256-SHA          Curve [32m25519[0m DHE 253
-Accepted  [33mTLSv1.1[0m  [32m256[0m bits  DHE-RSA-AES256-SHA            DHE 2048 bits
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  ECDHE-RSA-AES128-SHA          Curve [32m25519[0m DHE 253
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  DHE-RSA-AES128-SHA            DHE 2048 bits
-Accepted  [33mTLSv1.1[0m  [32m256[0m bits  AES256-SHA                   
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  AES128-SHA                   
-[32mPreferred[0m [33mTLSv1.0[0m  [32m256[0m bits  ECDHE-RSA-AES256-SHA          Curve [32m25519[0m DHE 253
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  DHE-RSA-AES256-SHA            DHE 2048 bits
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  ECDHE-RSA-AES128-SHA          Curve [32m25519[0m DHE 253
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  DHE-RSA-AES128-SHA            DHE 2048 bits
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  AES256-SHA                   
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  AES128-SHA                   
+Accepted  TLSv1.2  [32m256[0m bits  [33mAES256-SHA                   [0m
+Accepted  TLSv1.2  [32m128[0m bits  [33mAES128-SHA                   [0m
+[32mPreferred[0m [33mTLSv1.1[0m  [32m256[0m bits  [33mECDHE-RSA-AES256-SHA         [0m Curve [32m25519[0m DHE 253
+Accepted  [33mTLSv1.1[0m  [32m256[0m bits  [33mDHE-RSA-AES256-SHA           [0m DHE 2048 bits
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mECDHE-RSA-AES128-SHA         [0m Curve [32m25519[0m DHE 253
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mDHE-RSA-AES128-SHA           [0m DHE 2048 bits
+Accepted  [33mTLSv1.1[0m  [32m256[0m bits  [33mAES256-SHA                   [0m
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mAES128-SHA                   [0m
+[32mPreferred[0m [33mTLSv1.0[0m  [32m256[0m bits  [33mECDHE-RSA-AES256-SHA         [0m Curve [32m25519[0m DHE 253
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mDHE-RSA-AES256-SHA           [0m DHE 2048 bits
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mECDHE-RSA-AES128-SHA         [0m Curve [32m25519[0m DHE 253
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mDHE-RSA-AES128-SHA           [0m DHE 2048 bits
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mAES256-SHA                   [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mAES128-SHA                   [0m
 
   [1;34mServer Key Exchange Group(s):[0m
 TLSv1.3  [32m128[0m bits  secp256r1 (NIST P-256)[0m

--- a/docker_test/expected_output/test_14.txt
+++ b/docker_test/expected_output/test_14.txt
@@ -37,16 +37,16 @@ Accepted  TLSv1.2  [32m256[0m bits  DHE-RSA-AES256-CCM            DHE 8192 bit
 Accepted  TLSv1.2  [32m128[0m bits  [32mECDHE-RSA-AES128-GCM-SHA256  [0m Curve P-521 DHE 521
 Accepted  TLSv1.2  [32m128[0m bits  [32mDHE-RSA-AES128-GCM-SHA256    [0m DHE 8192 bits
 Accepted  TLSv1.2  [32m128[0m bits  DHE-RSA-AES128-CCM            DHE 8192 bits
-Accepted  TLSv1.2  [32m256[0m bits  ECDHE-RSA-AES256-SHA          Curve P-521 DHE 521
-Accepted  TLSv1.2  [32m256[0m bits  DHE-RSA-AES256-SHA            DHE 8192 bits
-Accepted  TLSv1.2  [32m128[0m bits  ECDHE-RSA-AES128-SHA          Curve P-521 DHE 521
-Accepted  TLSv1.2  [32m128[0m bits  DHE-RSA-AES128-SHA            DHE 8192 bits
+Accepted  TLSv1.2  [32m256[0m bits  [33mECDHE-RSA-AES256-SHA         [0m Curve P-521 DHE 521
+Accepted  TLSv1.2  [32m256[0m bits  [33mDHE-RSA-AES256-SHA           [0m DHE 8192 bits
+Accepted  TLSv1.2  [32m128[0m bits  [33mECDHE-RSA-AES128-SHA         [0m Curve P-521 DHE 521
+Accepted  TLSv1.2  [32m128[0m bits  [33mDHE-RSA-AES128-SHA           [0m DHE 8192 bits
 Accepted  TLSv1.2  [32m256[0m bits  AES256-GCM-SHA384            
 Accepted  TLSv1.2  [32m256[0m bits  AES256-CCM                   
 Accepted  TLSv1.2  [32m128[0m bits  AES128-GCM-SHA256            
 Accepted  TLSv1.2  [32m128[0m bits  AES128-CCM                   
-Accepted  TLSv1.2  [32m256[0m bits  AES256-SHA                   
-Accepted  TLSv1.2  [32m128[0m bits  AES128-SHA                   
+Accepted  TLSv1.2  [32m256[0m bits  [33mAES256-SHA                   [0m
+Accepted  TLSv1.2  [32m128[0m bits  [33mAES128-SHA                   [0m
 
   [1;34mServer Key Exchange Group(s):[0m
 TLSv1.3  [32m260[0m bits  secp521r1 (NIST P-521)[0m

--- a/docker_test/expected_output/test_15.txt
+++ b/docker_test/expected_output/test_15.txt
@@ -36,12 +36,12 @@ Accepted  TLSv1.2  [32m256[0m bits  [32mECDHE-ECDSA-CHACHA20-POLY1305[0m Cur
 Accepted  TLSv1.2  [32m256[0m bits  ECDHE-ECDSA-AES256-CCM        Curve [32m25519[0m DHE 253
 Accepted  TLSv1.2  [32m128[0m bits  [32mECDHE-ECDSA-AES128-GCM-SHA256[0m Curve [32m25519[0m DHE 253
 Accepted  TLSv1.2  [32m128[0m bits  ECDHE-ECDSA-AES128-CCM        Curve [32m25519[0m DHE 253
-Accepted  TLSv1.2  [32m256[0m bits  ECDHE-ECDSA-AES256-SHA        Curve [32m25519[0m DHE 253
-Accepted  TLSv1.2  [32m128[0m bits  ECDHE-ECDSA-AES128-SHA        Curve [32m25519[0m DHE 253
-[32mPreferred[0m [33mTLSv1.1[0m  [32m256[0m bits  ECDHE-ECDSA-AES256-SHA        Curve [32m25519[0m DHE 253
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  ECDHE-ECDSA-AES128-SHA        Curve [32m25519[0m DHE 253
-[32mPreferred[0m [33mTLSv1.0[0m  [32m256[0m bits  ECDHE-ECDSA-AES256-SHA        Curve [32m25519[0m DHE 253
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  ECDHE-ECDSA-AES128-SHA        Curve [32m25519[0m DHE 253
+Accepted  TLSv1.2  [32m256[0m bits  [33mECDHE-ECDSA-AES256-SHA       [0m Curve [32m25519[0m DHE 253
+Accepted  TLSv1.2  [32m128[0m bits  [33mECDHE-ECDSA-AES128-SHA       [0m Curve [32m25519[0m DHE 253
+[32mPreferred[0m [33mTLSv1.1[0m  [32m256[0m bits  [33mECDHE-ECDSA-AES256-SHA       [0m Curve [32m25519[0m DHE 253
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mECDHE-ECDSA-AES128-SHA       [0m Curve [32m25519[0m DHE 253
+[32mPreferred[0m [33mTLSv1.0[0m  [32m256[0m bits  [33mECDHE-ECDSA-AES256-SHA       [0m Curve [32m25519[0m DHE 253
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mECDHE-ECDSA-AES128-SHA       [0m Curve [32m25519[0m DHE 253
 
   [1;34mServer Key Exchange Group(s):[0m
 TLSv1.3  [32m128[0m bits  secp256r1 (NIST P-256)[0m

--- a/docker_test/expected_output/test_16.txt
+++ b/docker_test/expected_output/test_16.txt
@@ -28,25 +28,25 @@ TLSv1.2 [32mnot vulnerable[0m to heartbleed
 Accepted  TLSv1.2  [32m128[0m bits  [32mDHE-RSA-AES128-GCM-SHA256    [0m DHE 2048 bits
 Accepted  TLSv1.2  [32m256[0m bits  DHE-RSA-AES256-SHA256         DHE 2048 bits
 Accepted  TLSv1.2  [32m128[0m bits  DHE-RSA-AES128-SHA256         DHE 2048 bits
-Accepted  TLSv1.2  [32m256[0m bits  DHE-RSA-AES256-SHA            DHE 2048 bits
-Accepted  TLSv1.2  [32m256[0m bits  DHE-RSA-CAMELLIA256-SHA       DHE 2048 bits
-Accepted  TLSv1.2  [32m128[0m bits  DHE-RSA-AES128-SHA            DHE 2048 bits
-Accepted  TLSv1.2  [32m128[0m bits  DHE-RSA-CAMELLIA128-SHA       DHE 2048 bits
-Accepted  TLSv1.2  [32m112[0m bits  [33mDHE-RSA-DES-CBC3-SHA         [0m DHE 2048 bits
+Accepted  TLSv1.2  [32m256[0m bits  [33mDHE-RSA-AES256-SHA           [0m DHE 2048 bits
+Accepted  TLSv1.2  [32m256[0m bits  [33mDHE-RSA-CAMELLIA256-SHA      [0m DHE 2048 bits
+Accepted  TLSv1.2  [32m128[0m bits  [33mDHE-RSA-AES128-SHA           [0m DHE 2048 bits
+Accepted  TLSv1.2  [32m128[0m bits  [33mDHE-RSA-CAMELLIA128-SHA      [0m DHE 2048 bits
+Accepted  TLSv1.2  [33m112[0m bits  [33mDHE-RSA-DES-CBC3-SHA         [0m DHE 2048 bits
 Accepted  TLSv1.2  [32m256[0m bits  AES256-GCM-SHA384            
 Accepted  TLSv1.2  [32m128[0m bits  AES128-GCM-SHA256            
 Accepted  TLSv1.2  [32m256[0m bits  AES256-SHA256                
 Accepted  TLSv1.2  [32m128[0m bits  AES128-SHA256                
-Accepted  TLSv1.2  [32m256[0m bits  AES256-SHA                   
-Accepted  TLSv1.2  [32m256[0m bits  CAMELLIA256-SHA              
-Accepted  TLSv1.2  [32m128[0m bits  AES128-SHA                   
-Accepted  TLSv1.2  [32m128[0m bits  CAMELLIA128-SHA              
-Accepted  TLSv1.2  [32m112[0m bits  [33mDES-CBC3-SHA                 [0m
-Accepted  TLSv1.2  [32m128[0m bits  [33mTLS_RSA_WITH_RC4_128_MD5     [0m
+Accepted  TLSv1.2  [32m256[0m bits  [33mAES256-SHA                   [0m
+Accepted  TLSv1.2  [32m256[0m bits  [33mCAMELLIA256-SHA              [0m
+Accepted  TLSv1.2  [32m128[0m bits  [33mAES128-SHA                   [0m
+Accepted  TLSv1.2  [32m128[0m bits  [33mCAMELLIA128-SHA              [0m
+Accepted  TLSv1.2  [33m112[0m bits  [33mDES-CBC3-SHA                 [0m
+Accepted  TLSv1.2  [32m128[0m bits  [31mTLS_RSA_WITH_RC4_128_MD5     [0m
 Accepted  TLSv1.2  [32m128[0m bits  [33mTLS_RSA_WITH_RC4_128_SHA     [0m
-Accepted  TLSv1.2  [32m128[0m bits  TLS_RSA_WITH_IDEA_CBC_SHA    
-Accepted  TLSv1.2  [32m128[0m bits  TLS_RSA_WITH_SEED_CBC_SHA    
-Accepted  TLSv1.2  [32m128[0m bits  TLS_DHE_RSA_WITH_SEED_CBC_SHA
+Accepted  TLSv1.2  [32m128[0m bits  [33mTLS_RSA_WITH_IDEA_CBC_SHA    [0m
+Accepted  TLSv1.2  [32m128[0m bits  [33mTLS_RSA_WITH_SEED_CBC_SHA    [0m
+Accepted  TLSv1.2  [32m128[0m bits  [33mTLS_DHE_RSA_WITH_SEED_CBC_SHA[0m
 
   [1;34mServer Key Exchange Group(s):[0m
 TLSv1.2  [31m81[0m bits  [31msect163k1[0m

--- a/docker_test/expected_output/test_17.txt
+++ b/docker_test/expected_output/test_17.txt
@@ -24,19 +24,19 @@ Compression [32mdisabled[0m
 TLSv1.2 [32mnot vulnerable[0m to heartbleed
 
   [1;34mSupported Server Cipher(s):[0m
-[32mPreferred[0m TLSv1.2  [32m256[0m bits  [32mDHE-RSA-AES256-GCM-SHA384    [0m DHE [33m1024[0m bits
-Accepted  TLSv1.2  [32m256[0m bits  [32mDHE-RSA-CHACHA20-POLY1305    [0m DHE [33m1024[0m bits
-Accepted  TLSv1.2  [32m128[0m bits  [32mDHE-RSA-AES128-GCM-SHA256    [0m DHE [33m1024[0m bits
-Accepted  TLSv1.2  [32m256[0m bits  DHE-RSA-AES256-SHA256         DHE [33m1024[0m bits
-Accepted  TLSv1.2  [32m128[0m bits  DHE-RSA-AES128-SHA256         DHE [33m1024[0m bits
-Accepted  TLSv1.2  [32m256[0m bits  DHE-RSA-AES256-SHA            DHE [33m1024[0m bits
-Accepted  TLSv1.2  [32m128[0m bits  DHE-RSA-AES128-SHA            DHE [33m1024[0m bits
+[32mPreferred[0m TLSv1.2  [32m256[0m bits  [32mDHE-RSA-AES256-GCM-SHA384    [0m DHE [31m1024[0m bits
+Accepted  TLSv1.2  [32m256[0m bits  [32mDHE-RSA-CHACHA20-POLY1305    [0m DHE [31m1024[0m bits
+Accepted  TLSv1.2  [32m128[0m bits  [32mDHE-RSA-AES128-GCM-SHA256    [0m DHE [31m1024[0m bits
+Accepted  TLSv1.2  [32m256[0m bits  DHE-RSA-AES256-SHA256         DHE [31m1024[0m bits
+Accepted  TLSv1.2  [32m128[0m bits  DHE-RSA-AES128-SHA256         DHE [31m1024[0m bits
+Accepted  TLSv1.2  [32m256[0m bits  [33mDHE-RSA-AES256-SHA           [0m DHE [31m1024[0m bits
+Accepted  TLSv1.2  [32m128[0m bits  [33mDHE-RSA-AES128-SHA           [0m DHE [31m1024[0m bits
 Accepted  TLSv1.2  [32m256[0m bits  AES256-GCM-SHA384            
 Accepted  TLSv1.2  [32m128[0m bits  AES128-GCM-SHA256            
 Accepted  TLSv1.2  [32m256[0m bits  AES256-SHA256                
 Accepted  TLSv1.2  [32m128[0m bits  AES128-SHA256                
-Accepted  TLSv1.2  [32m256[0m bits  AES256-SHA                   
-Accepted  TLSv1.2  [32m128[0m bits  AES128-SHA                   
+Accepted  TLSv1.2  [32m256[0m bits  [33mAES256-SHA                   [0m
+Accepted  TLSv1.2  [32m128[0m bits  [33mAES128-SHA                   [0m
 
   [1;34mServer Key Exchange Group(s):[0m
 TLSv1.2  [32m256[0m bits  brainpoolP512r1[0m

--- a/docker_test/expected_output/test_4.txt
+++ b/docker_test/expected_output/test_4.txt
@@ -40,28 +40,28 @@ Accepted  TLSv1.2  [32m256[0m bits  ECDHE-RSA-AES256-SHA384       Curve [32m2
 Accepted  TLSv1.2  [32m256[0m bits  DHE-RSA-AES256-SHA256         DHE 3072 bits
 Accepted  TLSv1.2  [32m128[0m bits  ECDHE-RSA-AES128-SHA256       Curve [32m25519[0m DHE 253
 Accepted  TLSv1.2  [32m128[0m bits  DHE-RSA-AES128-SHA256         DHE 3072 bits
-Accepted  TLSv1.2  [32m256[0m bits  ECDHE-RSA-AES256-SHA          Curve [32m25519[0m DHE 253
-Accepted  TLSv1.2  [32m256[0m bits  DHE-RSA-AES256-SHA            DHE 3072 bits
-Accepted  TLSv1.2  [32m128[0m bits  ECDHE-RSA-AES128-SHA          Curve [32m25519[0m DHE 253
-Accepted  TLSv1.2  [32m128[0m bits  DHE-RSA-AES128-SHA            DHE 3072 bits
+Accepted  TLSv1.2  [32m256[0m bits  [33mECDHE-RSA-AES256-SHA         [0m Curve [32m25519[0m DHE 253
+Accepted  TLSv1.2  [32m256[0m bits  [33mDHE-RSA-AES256-SHA           [0m DHE 3072 bits
+Accepted  TLSv1.2  [32m128[0m bits  [33mECDHE-RSA-AES128-SHA         [0m Curve [32m25519[0m DHE 253
+Accepted  TLSv1.2  [32m128[0m bits  [33mDHE-RSA-AES128-SHA           [0m DHE 3072 bits
 Accepted  TLSv1.2  [32m256[0m bits  AES256-GCM-SHA384            
 Accepted  TLSv1.2  [32m128[0m bits  AES128-GCM-SHA256            
 Accepted  TLSv1.2  [32m256[0m bits  AES256-SHA256                
 Accepted  TLSv1.2  [32m128[0m bits  AES128-SHA256                
-Accepted  TLSv1.2  [32m256[0m bits  AES256-SHA                   
-Accepted  TLSv1.2  [32m128[0m bits  AES128-SHA                   
-[32mPreferred[0m [33mTLSv1.1[0m  [32m256[0m bits  ECDHE-RSA-AES256-SHA          Curve [32m25519[0m DHE 253
-Accepted  [33mTLSv1.1[0m  [32m256[0m bits  DHE-RSA-AES256-SHA            DHE 3072 bits
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  ECDHE-RSA-AES128-SHA          Curve [32m25519[0m DHE 253
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  DHE-RSA-AES128-SHA            DHE 3072 bits
-Accepted  [33mTLSv1.1[0m  [32m256[0m bits  AES256-SHA                   
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  AES128-SHA                   
-[32mPreferred[0m [33mTLSv1.0[0m  [32m256[0m bits  ECDHE-RSA-AES256-SHA          Curve [32m25519[0m DHE 253
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  DHE-RSA-AES256-SHA            DHE 3072 bits
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  ECDHE-RSA-AES128-SHA          Curve [32m25519[0m DHE 253
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  DHE-RSA-AES128-SHA            DHE 3072 bits
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  AES256-SHA                   
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  AES128-SHA                   
+Accepted  TLSv1.2  [32m256[0m bits  [33mAES256-SHA                   [0m
+Accepted  TLSv1.2  [32m128[0m bits  [33mAES128-SHA                   [0m
+[32mPreferred[0m [33mTLSv1.1[0m  [32m256[0m bits  [33mECDHE-RSA-AES256-SHA         [0m Curve [32m25519[0m DHE 253
+Accepted  [33mTLSv1.1[0m  [32m256[0m bits  [33mDHE-RSA-AES256-SHA           [0m DHE 3072 bits
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mECDHE-RSA-AES128-SHA         [0m Curve [32m25519[0m DHE 253
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mDHE-RSA-AES128-SHA           [0m DHE 3072 bits
+Accepted  [33mTLSv1.1[0m  [32m256[0m bits  [33mAES256-SHA                   [0m
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mAES128-SHA                   [0m
+[32mPreferred[0m [33mTLSv1.0[0m  [32m256[0m bits  [33mECDHE-RSA-AES256-SHA         [0m Curve [32m25519[0m DHE 253
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mDHE-RSA-AES256-SHA           [0m DHE 3072 bits
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mECDHE-RSA-AES128-SHA         [0m Curve [32m25519[0m DHE 253
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mDHE-RSA-AES128-SHA           [0m DHE 3072 bits
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mAES256-SHA                   [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mAES128-SHA                   [0m
 
   [1;34mServer Key Exchange Group(s):[0m
 TLSv1.3  [32m128[0m bits  secp256r1 (NIST P-256)[0m

--- a/docker_test/expected_output/test_5.txt
+++ b/docker_test/expected_output/test_5.txt
@@ -27,129 +27,129 @@ TLSv1.0 [32mnot vulnerable[0m to heartbleed
 
   [1;34mSupported Server Cipher(s):[0m
 [32mPreferred[0m TLSv1.2  [32m256[0m bits  [32mECDHE-RSA-AES256-GCM-SHA384  [0m Curve P-256 DHE 256
-Accepted  TLSv1.2  [32m256[0m bits  [32mDHE-RSA-AES256-GCM-SHA384    [0m DHE [33m1024[0m bits
-Accepted  TLSv1.2  [32m256[0m bits  [35mADH-AES256-GCM-SHA384        [0m DHE [33m1024[0m bits
+Accepted  TLSv1.2  [32m256[0m bits  [32mDHE-RSA-AES256-GCM-SHA384    [0m DHE [31m1024[0m bits
+Accepted  TLSv1.2  [32m256[0m bits  [41mADH-AES256-GCM-SHA384        [0m DHE [31m1024[0m bits
 Accepted  TLSv1.2  [32m128[0m bits  [32mECDHE-RSA-AES128-GCM-SHA256  [0m Curve P-256 DHE 256
-Accepted  TLSv1.2  [32m128[0m bits  [32mDHE-RSA-AES128-GCM-SHA256    [0m DHE [33m1024[0m bits
-Accepted  TLSv1.2  [32m128[0m bits  [35mADH-AES128-GCM-SHA256        [0m DHE [33m1024[0m bits
+Accepted  TLSv1.2  [32m128[0m bits  [32mDHE-RSA-AES128-GCM-SHA256    [0m DHE [31m1024[0m bits
+Accepted  TLSv1.2  [32m128[0m bits  [41mADH-AES128-GCM-SHA256        [0m DHE [31m1024[0m bits
 Accepted  TLSv1.2  [32m256[0m bits  ECDHE-RSA-AES256-SHA384       Curve P-256 DHE 256
-Accepted  TLSv1.2  [32m256[0m bits  DHE-RSA-AES256-SHA256         DHE [33m1024[0m bits
-Accepted  TLSv1.2  [32m256[0m bits  [35mADH-AES256-SHA256            [0m DHE [33m1024[0m bits
+Accepted  TLSv1.2  [32m256[0m bits  DHE-RSA-AES256-SHA256         DHE [31m1024[0m bits
+Accepted  TLSv1.2  [32m256[0m bits  [41mADH-AES256-SHA256            [0m DHE [31m1024[0m bits
 Accepted  TLSv1.2  [32m128[0m bits  ECDHE-RSA-AES128-SHA256       Curve P-256 DHE 256
-Accepted  TLSv1.2  [32m128[0m bits  DHE-RSA-AES128-SHA256         DHE [33m1024[0m bits
-Accepted  TLSv1.2  [32m128[0m bits  [35mADH-AES128-SHA256            [0m DHE [33m1024[0m bits
-Accepted  TLSv1.2  [32m256[0m bits  ECDHE-RSA-AES256-SHA          Curve P-256 DHE 256
-Accepted  TLSv1.2  [32m256[0m bits  DHE-RSA-AES256-SHA            DHE [33m1024[0m bits
-Accepted  TLSv1.2  [32m256[0m bits  DHE-RSA-CAMELLIA256-SHA       DHE [33m1024[0m bits
-Accepted  TLSv1.2  [32m256[0m bits  [35mAECDH-AES256-SHA             [0m Curve P-256 DHE 256
-Accepted  TLSv1.2  [32m256[0m bits  [35mADH-AES256-SHA               [0m DHE [33m1024[0m bits
-Accepted  TLSv1.2  [32m256[0m bits  [35mADH-CAMELLIA256-SHA          [0m DHE [33m1024[0m bits
-Accepted  TLSv1.2  [32m128[0m bits  ECDHE-RSA-AES128-SHA          Curve P-256 DHE 256
-Accepted  TLSv1.2  [32m128[0m bits  DHE-RSA-AES128-SHA            DHE [33m1024[0m bits
-Accepted  TLSv1.2  [32m128[0m bits  DHE-RSA-CAMELLIA128-SHA       DHE [33m1024[0m bits
-Accepted  TLSv1.2  [32m128[0m bits  [35mAECDH-AES128-SHA             [0m Curve P-256 DHE 256
-Accepted  TLSv1.2  [32m128[0m bits  [35mADH-AES128-SHA               [0m DHE [33m1024[0m bits
-Accepted  TLSv1.2  [32m128[0m bits  [35mADH-CAMELLIA128-SHA          [0m DHE [33m1024[0m bits
-Accepted  TLSv1.2  [32m112[0m bits  [33mECDHE-RSA-DES-CBC3-SHA       [0m Curve P-256 DHE 256
-Accepted  TLSv1.2  [32m112[0m bits  [33mDHE-RSA-DES-CBC3-SHA         [0m DHE [33m1024[0m bits
-Accepted  TLSv1.2  [32m112[0m bits  [35mAECDH-DES-CBC3-SHA           [0m Curve P-256 DHE 256
-Accepted  TLSv1.2  [32m112[0m bits  [35mADH-DES-CBC3-SHA             [0m DHE [33m1024[0m bits
+Accepted  TLSv1.2  [32m128[0m bits  DHE-RSA-AES128-SHA256         DHE [31m1024[0m bits
+Accepted  TLSv1.2  [32m128[0m bits  [41mADH-AES128-SHA256            [0m DHE [31m1024[0m bits
+Accepted  TLSv1.2  [32m256[0m bits  [33mECDHE-RSA-AES256-SHA         [0m Curve P-256 DHE 256
+Accepted  TLSv1.2  [32m256[0m bits  [33mDHE-RSA-AES256-SHA           [0m DHE [31m1024[0m bits
+Accepted  TLSv1.2  [32m256[0m bits  [33mDHE-RSA-CAMELLIA256-SHA      [0m DHE [31m1024[0m bits
+Accepted  TLSv1.2  [32m256[0m bits  [41mAECDH-AES256-SHA             [0m Curve P-256 DHE 256
+Accepted  TLSv1.2  [32m256[0m bits  [41mADH-AES256-SHA               [0m DHE [31m1024[0m bits
+Accepted  TLSv1.2  [32m256[0m bits  [41mADH-CAMELLIA256-SHA          [0m DHE [31m1024[0m bits
+Accepted  TLSv1.2  [32m128[0m bits  [33mECDHE-RSA-AES128-SHA         [0m Curve P-256 DHE 256
+Accepted  TLSv1.2  [32m128[0m bits  [33mDHE-RSA-AES128-SHA           [0m DHE [31m1024[0m bits
+Accepted  TLSv1.2  [32m128[0m bits  [33mDHE-RSA-CAMELLIA128-SHA      [0m DHE [31m1024[0m bits
+Accepted  TLSv1.2  [32m128[0m bits  [41mAECDH-AES128-SHA             [0m Curve P-256 DHE 256
+Accepted  TLSv1.2  [32m128[0m bits  [41mADH-AES128-SHA               [0m DHE [31m1024[0m bits
+Accepted  TLSv1.2  [32m128[0m bits  [41mADH-CAMELLIA128-SHA          [0m DHE [31m1024[0m bits
+Accepted  TLSv1.2  [33m112[0m bits  [33mECDHE-RSA-DES-CBC3-SHA       [0m Curve P-256 DHE 256
+Accepted  TLSv1.2  [33m112[0m bits  [33mDHE-RSA-DES-CBC3-SHA         [0m DHE [31m1024[0m bits
+Accepted  TLSv1.2  [33m112[0m bits  [41mAECDH-DES-CBC3-SHA           [0m Curve P-256 DHE 256
+Accepted  TLSv1.2  [33m112[0m bits  [41mADH-DES-CBC3-SHA             [0m DHE [31m1024[0m bits
 Accepted  TLSv1.2  [32m256[0m bits  AES256-GCM-SHA384            
 Accepted  TLSv1.2  [32m128[0m bits  AES128-GCM-SHA256            
 Accepted  TLSv1.2  [32m256[0m bits  AES256-SHA256                
 Accepted  TLSv1.2  [32m128[0m bits  AES128-SHA256                
-Accepted  TLSv1.2  [32m256[0m bits  AES256-SHA                   
-Accepted  TLSv1.2  [32m256[0m bits  CAMELLIA256-SHA              
-Accepted  TLSv1.2  [32m128[0m bits  AES128-SHA                   
-Accepted  TLSv1.2  [32m128[0m bits  CAMELLIA128-SHA              
-Accepted  TLSv1.2  [32m112[0m bits  [33mDES-CBC3-SHA                 [0m
+Accepted  TLSv1.2  [32m256[0m bits  [33mAES256-SHA                   [0m
+Accepted  TLSv1.2  [32m256[0m bits  [33mCAMELLIA256-SHA              [0m
+Accepted  TLSv1.2  [32m128[0m bits  [33mAES128-SHA                   [0m
+Accepted  TLSv1.2  [32m128[0m bits  [33mCAMELLIA128-SHA              [0m
+Accepted  TLSv1.2  [33m112[0m bits  [33mDES-CBC3-SHA                 [0m
 Accepted  TLSv1.2  [31m40[0m bits   [31mTLS_RSA_EXPORT_WITH_RC4_40_MD5[0m
-Accepted  TLSv1.2  [32m128[0m bits  [33mTLS_RSA_WITH_RC4_128_MD5     [0m
+Accepted  TLSv1.2  [32m128[0m bits  [31mTLS_RSA_WITH_RC4_128_MD5     [0m
 Accepted  TLSv1.2  [32m128[0m bits  [33mTLS_RSA_WITH_RC4_128_SHA     [0m
 Accepted  TLSv1.2  [31m40[0m bits   [31mTLS_RSA_EXPORT_WITH_RC2_CBC_40_MD5[0m
-Accepted  TLSv1.2  [32m128[0m bits  TLS_RSA_WITH_IDEA_CBC_SHA    
+Accepted  TLSv1.2  [32m128[0m bits  [33mTLS_RSA_WITH_IDEA_CBC_SHA    [0m
 Accepted  TLSv1.2  [31m40[0m bits   [31mTLS_RSA_EXPORT_WITH_DES40_CBC_SHA[0m
 Accepted  TLSv1.2  [31m56[0m bits   [33mTLS_RSA_WITH_DES_CBC_SHA     [0m
 Accepted  TLSv1.2  [31m56[0m bits   [33mTLS_DHE_RSA_WITH_DES_CBC_SHA [0m
-Accepted  TLSv1.2  [32m128[0m bits  [35mTLS_DH_anon_WITH_RC4_128_MD5 [0m
-Accepted  TLSv1.2  [31m56[0m bits   [35mTLS_DH_anon_WITH_DES_CBC_SHA [0m
-Accepted  TLSv1.2  [32m128[0m bits  TLS_RSA_WITH_SEED_CBC_SHA    
-Accepted  TLSv1.2  [32m128[0m bits  TLS_DHE_RSA_WITH_SEED_CBC_SHA
-Accepted  TLSv1.2  [32m128[0m bits  [35mTLS_DH_anon_WITH_SEED_CBC_SHA[0m
+Accepted  TLSv1.2  [32m128[0m bits  [41mTLS_DH_anon_WITH_RC4_128_MD5 [0m
+Accepted  TLSv1.2  [31m56[0m bits   [41mTLS_DH_anon_WITH_DES_CBC_SHA [0m
+Accepted  TLSv1.2  [32m128[0m bits  [33mTLS_RSA_WITH_SEED_CBC_SHA    [0m
+Accepted  TLSv1.2  [32m128[0m bits  [33mTLS_DHE_RSA_WITH_SEED_CBC_SHA[0m
+Accepted  TLSv1.2  [32m128[0m bits  [41mTLS_DH_anon_WITH_SEED_CBC_SHA[0m
 Accepted  TLSv1.2  [32m128[0m bits  [33mTLS_ECDHE_RSA_WITH_RC4_128_SHA[0m
-Accepted  TLSv1.2  [32m128[0m bits  [35mTLS_ECDH_anon_WITH_RC4_128_SHA[0m
-[32mPreferred[0m [33mTLSv1.1[0m  [32m256[0m bits  ECDHE-RSA-AES256-SHA          Curve P-256 DHE 256
-Accepted  [33mTLSv1.1[0m  [32m256[0m bits  DHE-RSA-AES256-SHA            DHE [33m1024[0m bits
-Accepted  [33mTLSv1.1[0m  [32m256[0m bits  DHE-RSA-CAMELLIA256-SHA       DHE [33m1024[0m bits
-Accepted  [33mTLSv1.1[0m  [32m256[0m bits  [35mAECDH-AES256-SHA             [0m Curve P-256 DHE 256
-Accepted  [33mTLSv1.1[0m  [32m256[0m bits  [35mADH-AES256-SHA               [0m DHE [33m1024[0m bits
-Accepted  [33mTLSv1.1[0m  [32m256[0m bits  [35mADH-CAMELLIA256-SHA          [0m DHE [33m1024[0m bits
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  ECDHE-RSA-AES128-SHA          Curve P-256 DHE 256
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  DHE-RSA-AES128-SHA            DHE [33m1024[0m bits
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  DHE-RSA-CAMELLIA128-SHA       DHE [33m1024[0m bits
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [35mAECDH-AES128-SHA             [0m Curve P-256 DHE 256
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [35mADH-AES128-SHA               [0m DHE [33m1024[0m bits
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [35mADH-CAMELLIA128-SHA          [0m DHE [33m1024[0m bits
-Accepted  [33mTLSv1.1[0m  [32m112[0m bits  [33mECDHE-RSA-DES-CBC3-SHA       [0m Curve P-256 DHE 256
-Accepted  [33mTLSv1.1[0m  [32m112[0m bits  [33mDHE-RSA-DES-CBC3-SHA         [0m DHE [33m1024[0m bits
-Accepted  [33mTLSv1.1[0m  [32m112[0m bits  [35mAECDH-DES-CBC3-SHA           [0m Curve P-256 DHE 256
-Accepted  [33mTLSv1.1[0m  [32m112[0m bits  [35mADH-DES-CBC3-SHA             [0m DHE [33m1024[0m bits
-Accepted  [33mTLSv1.1[0m  [32m256[0m bits  AES256-SHA                   
-Accepted  [33mTLSv1.1[0m  [32m256[0m bits  CAMELLIA256-SHA              
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  AES128-SHA                   
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  CAMELLIA128-SHA              
-Accepted  [33mTLSv1.1[0m  [32m112[0m bits  [33mDES-CBC3-SHA                 [0m
+Accepted  TLSv1.2  [32m128[0m bits  [41mTLS_ECDH_anon_WITH_RC4_128_SHA[0m
+[32mPreferred[0m [33mTLSv1.1[0m  [32m256[0m bits  [33mECDHE-RSA-AES256-SHA         [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.1[0m  [32m256[0m bits  [33mDHE-RSA-AES256-SHA           [0m DHE [31m1024[0m bits
+Accepted  [33mTLSv1.1[0m  [32m256[0m bits  [33mDHE-RSA-CAMELLIA256-SHA      [0m DHE [31m1024[0m bits
+Accepted  [33mTLSv1.1[0m  [32m256[0m bits  [41mAECDH-AES256-SHA             [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.1[0m  [32m256[0m bits  [41mADH-AES256-SHA               [0m DHE [31m1024[0m bits
+Accepted  [33mTLSv1.1[0m  [32m256[0m bits  [41mADH-CAMELLIA256-SHA          [0m DHE [31m1024[0m bits
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mECDHE-RSA-AES128-SHA         [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mDHE-RSA-AES128-SHA           [0m DHE [31m1024[0m bits
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mDHE-RSA-CAMELLIA128-SHA      [0m DHE [31m1024[0m bits
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [41mAECDH-AES128-SHA             [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [41mADH-AES128-SHA               [0m DHE [31m1024[0m bits
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [41mADH-CAMELLIA128-SHA          [0m DHE [31m1024[0m bits
+Accepted  [33mTLSv1.1[0m  [33m112[0m bits  [33mECDHE-RSA-DES-CBC3-SHA       [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.1[0m  [33m112[0m bits  [33mDHE-RSA-DES-CBC3-SHA         [0m DHE [31m1024[0m bits
+Accepted  [33mTLSv1.1[0m  [33m112[0m bits  [41mAECDH-DES-CBC3-SHA           [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.1[0m  [33m112[0m bits  [41mADH-DES-CBC3-SHA             [0m DHE [31m1024[0m bits
+Accepted  [33mTLSv1.1[0m  [32m256[0m bits  [33mAES256-SHA                   [0m
+Accepted  [33mTLSv1.1[0m  [32m256[0m bits  [33mCAMELLIA256-SHA              [0m
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mAES128-SHA                   [0m
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mCAMELLIA128-SHA              [0m
+Accepted  [33mTLSv1.1[0m  [33m112[0m bits  [33mDES-CBC3-SHA                 [0m
 Accepted  [33mTLSv1.1[0m  [31m40[0m bits   [31mTLS_RSA_EXPORT_WITH_RC4_40_MD5[0m
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mTLS_RSA_WITH_RC4_128_MD5     [0m
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [31mTLS_RSA_WITH_RC4_128_MD5     [0m
 Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mTLS_RSA_WITH_RC4_128_SHA     [0m
 Accepted  [33mTLSv1.1[0m  [31m40[0m bits   [31mTLS_RSA_EXPORT_WITH_RC2_CBC_40_MD5[0m
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  TLS_RSA_WITH_IDEA_CBC_SHA    
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mTLS_RSA_WITH_IDEA_CBC_SHA    [0m
 Accepted  [33mTLSv1.1[0m  [31m40[0m bits   [31mTLS_RSA_EXPORT_WITH_DES40_CBC_SHA[0m
 Accepted  [33mTLSv1.1[0m  [31m56[0m bits   [33mTLS_RSA_WITH_DES_CBC_SHA     [0m
 Accepted  [33mTLSv1.1[0m  [31m56[0m bits   [33mTLS_DHE_RSA_WITH_DES_CBC_SHA [0m
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [35mTLS_DH_anon_WITH_RC4_128_MD5 [0m
-Accepted  [33mTLSv1.1[0m  [31m56[0m bits   [35mTLS_DH_anon_WITH_DES_CBC_SHA [0m
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  TLS_RSA_WITH_SEED_CBC_SHA    
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  TLS_DHE_RSA_WITH_SEED_CBC_SHA
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [35mTLS_DH_anon_WITH_SEED_CBC_SHA[0m
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [41mTLS_DH_anon_WITH_RC4_128_MD5 [0m
+Accepted  [33mTLSv1.1[0m  [31m56[0m bits   [41mTLS_DH_anon_WITH_DES_CBC_SHA [0m
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mTLS_RSA_WITH_SEED_CBC_SHA    [0m
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mTLS_DHE_RSA_WITH_SEED_CBC_SHA[0m
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [41mTLS_DH_anon_WITH_SEED_CBC_SHA[0m
 Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [33mTLS_ECDHE_RSA_WITH_RC4_128_SHA[0m
-Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [35mTLS_ECDH_anon_WITH_RC4_128_SHA[0m
-[32mPreferred[0m [33mTLSv1.0[0m  [32m256[0m bits  ECDHE-RSA-AES256-SHA          Curve P-256 DHE 256
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  DHE-RSA-AES256-SHA            DHE [33m1024[0m bits
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  DHE-RSA-CAMELLIA256-SHA       DHE [33m1024[0m bits
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [35mAECDH-AES256-SHA             [0m Curve P-256 DHE 256
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [35mADH-AES256-SHA               [0m DHE [33m1024[0m bits
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [35mADH-CAMELLIA256-SHA          [0m DHE [33m1024[0m bits
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  ECDHE-RSA-AES128-SHA          Curve P-256 DHE 256
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  DHE-RSA-AES128-SHA            DHE [33m1024[0m bits
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  DHE-RSA-CAMELLIA128-SHA       DHE [33m1024[0m bits
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [35mAECDH-AES128-SHA             [0m Curve P-256 DHE 256
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [35mADH-AES128-SHA               [0m DHE [33m1024[0m bits
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [35mADH-CAMELLIA128-SHA          [0m DHE [33m1024[0m bits
-Accepted  [33mTLSv1.0[0m  [32m112[0m bits  [33mECDHE-RSA-DES-CBC3-SHA       [0m Curve P-256 DHE 256
-Accepted  [33mTLSv1.0[0m  [32m112[0m bits  [33mDHE-RSA-DES-CBC3-SHA         [0m DHE [33m1024[0m bits
-Accepted  [33mTLSv1.0[0m  [32m112[0m bits  [35mAECDH-DES-CBC3-SHA           [0m Curve P-256 DHE 256
-Accepted  [33mTLSv1.0[0m  [32m112[0m bits  [35mADH-DES-CBC3-SHA             [0m DHE [33m1024[0m bits
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  AES256-SHA                   
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  CAMELLIA256-SHA              
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  AES128-SHA                   
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  CAMELLIA128-SHA              
-Accepted  [33mTLSv1.0[0m  [32m112[0m bits  [33mDES-CBC3-SHA                 [0m
+Accepted  [33mTLSv1.1[0m  [32m128[0m bits  [41mTLS_ECDH_anon_WITH_RC4_128_SHA[0m
+[32mPreferred[0m [33mTLSv1.0[0m  [32m256[0m bits  [33mECDHE-RSA-AES256-SHA         [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mDHE-RSA-AES256-SHA           [0m DHE [31m1024[0m bits
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mDHE-RSA-CAMELLIA256-SHA      [0m DHE [31m1024[0m bits
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [41mAECDH-AES256-SHA             [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [41mADH-AES256-SHA               [0m DHE [31m1024[0m bits
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [41mADH-CAMELLIA256-SHA          [0m DHE [31m1024[0m bits
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mECDHE-RSA-AES128-SHA         [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mDHE-RSA-AES128-SHA           [0m DHE [31m1024[0m bits
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mDHE-RSA-CAMELLIA128-SHA      [0m DHE [31m1024[0m bits
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [41mAECDH-AES128-SHA             [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [41mADH-AES128-SHA               [0m DHE [31m1024[0m bits
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [41mADH-CAMELLIA128-SHA          [0m DHE [31m1024[0m bits
+Accepted  [33mTLSv1.0[0m  [33m112[0m bits  [33mECDHE-RSA-DES-CBC3-SHA       [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.0[0m  [33m112[0m bits  [33mDHE-RSA-DES-CBC3-SHA         [0m DHE [31m1024[0m bits
+Accepted  [33mTLSv1.0[0m  [33m112[0m bits  [41mAECDH-DES-CBC3-SHA           [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.0[0m  [33m112[0m bits  [41mADH-DES-CBC3-SHA             [0m DHE [31m1024[0m bits
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mAES256-SHA                   [0m
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mCAMELLIA256-SHA              [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mAES128-SHA                   [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mCAMELLIA128-SHA              [0m
+Accepted  [33mTLSv1.0[0m  [33m112[0m bits  [33mDES-CBC3-SHA                 [0m
 Accepted  [33mTLSv1.0[0m  [31m40[0m bits   [31mTLS_RSA_EXPORT_WITH_RC4_40_MD5[0m
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_RSA_WITH_RC4_128_MD5     [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [31mTLS_RSA_WITH_RC4_128_MD5     [0m
 Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_RSA_WITH_RC4_128_SHA     [0m
 Accepted  [33mTLSv1.0[0m  [31m40[0m bits   [31mTLS_RSA_EXPORT_WITH_RC2_CBC_40_MD5[0m
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  TLS_RSA_WITH_IDEA_CBC_SHA    
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_RSA_WITH_IDEA_CBC_SHA    [0m
 Accepted  [33mTLSv1.0[0m  [31m40[0m bits   [31mTLS_RSA_EXPORT_WITH_DES40_CBC_SHA[0m
 Accepted  [33mTLSv1.0[0m  [31m56[0m bits   [33mTLS_RSA_WITH_DES_CBC_SHA     [0m
 Accepted  [33mTLSv1.0[0m  [31m56[0m bits   [33mTLS_DHE_RSA_WITH_DES_CBC_SHA [0m
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [35mTLS_DH_anon_WITH_RC4_128_MD5 [0m
-Accepted  [33mTLSv1.0[0m  [31m56[0m bits   [35mTLS_DH_anon_WITH_DES_CBC_SHA [0m
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  TLS_RSA_WITH_SEED_CBC_SHA    
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  TLS_DHE_RSA_WITH_SEED_CBC_SHA
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [35mTLS_DH_anon_WITH_SEED_CBC_SHA[0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [41mTLS_DH_anon_WITH_RC4_128_MD5 [0m
+Accepted  [33mTLSv1.0[0m  [31m56[0m bits   [41mTLS_DH_anon_WITH_DES_CBC_SHA [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_RSA_WITH_SEED_CBC_SHA    [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_DHE_RSA_WITH_SEED_CBC_SHA[0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [41mTLS_DH_anon_WITH_SEED_CBC_SHA[0m
 Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_ECDHE_RSA_WITH_RC4_128_SHA[0m
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [35mTLS_ECDH_anon_WITH_RC4_128_SHA[0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [41mTLS_ECDH_anon_WITH_RC4_128_SHA[0m
 
   [1;34mServer Key Exchange Group(s):[0m
 TLSv1.2  [32m128[0m bits  secp256r1 (NIST P-256)[0m

--- a/docker_test/expected_output/test_6.txt
+++ b/docker_test/expected_output/test_6.txt
@@ -28,7 +28,7 @@ TLSv1.3 [32mnot vulnerable[0m to heartbleed
 Accepted  [32mTLSv1.3[0m  [32m256[0m bits  [32mTLS_AES_256_GCM_SHA384       [0m Curve [32m25519[0m DHE 253
 Accepted  [32mTLSv1.3[0m  [32m256[0m bits  [32mTLS_CHACHA20_POLY1305_SHA256 [0m Curve [32m25519[0m DHE 253
 Accepted  [32mTLSv1.3[0m  [32m128[0m bits  TLS_AES_128_CCM_SHA256        Curve [32m25519[0m DHE 253
-Accepted  [32mTLSv1.3[0m  [33m64[0m bits   TLS_AES_128_CCM_8_SHA256      Curve [32m25519[0m DHE 253
+Accepted  [32mTLSv1.3[0m  [31m64[0m bits   TLS_AES_128_CCM_8_SHA256      Curve [32m25519[0m DHE 253
 
   [1;34mServer Key Exchange Group(s):[0m
 TLSv1.3  [32m128[0m bits  secp256r1 (NIST P-256)[0m

--- a/docker_test/expected_output/test_7.txt
+++ b/docker_test/expected_output/test_7.txt
@@ -24,26 +24,26 @@ Compression [31menabled[0m (CRIME)
 TLSv1.0 [32mnot vulnerable[0m to heartbleed
 
   [1;34mSupported Server Cipher(s):[0m
-[32mPreferred[0m [33mTLSv1.0[0m  [32m256[0m bits  ECDHE-RSA-AES256-SHA          Curve P-256 DHE 256
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  DHE-RSA-AES256-SHA            DHE [31m512[0m bits
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  DHE-RSA-CAMELLIA256-SHA       DHE [31m512[0m bits
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  ECDHE-RSA-AES128-SHA          Curve P-256 DHE 256
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  DHE-RSA-AES128-SHA            DHE [31m512[0m bits
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  DHE-RSA-CAMELLIA128-SHA       DHE [31m512[0m bits
-Accepted  [33mTLSv1.0[0m  [32m112[0m bits  [33mECDHE-RSA-DES-CBC3-SHA       [0m Curve P-256 DHE 256
-Accepted  [33mTLSv1.0[0m  [32m112[0m bits  [33mDHE-RSA-DES-CBC3-SHA         [0m DHE [31m512[0m bits
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  AES256-SHA                   
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  CAMELLIA256-SHA              
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  AES128-SHA                   
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  CAMELLIA128-SHA              
-Accepted  [33mTLSv1.0[0m  [32m112[0m bits  [33mDES-CBC3-SHA                 [0m
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_RSA_WITH_RC4_128_MD5     [0m
+[32mPreferred[0m [33mTLSv1.0[0m  [32m256[0m bits  [33mECDHE-RSA-AES256-SHA         [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mDHE-RSA-AES256-SHA           [0m DHE [31m512[0m bits
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mDHE-RSA-CAMELLIA256-SHA      [0m DHE [31m512[0m bits
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mECDHE-RSA-AES128-SHA         [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mDHE-RSA-AES128-SHA           [0m DHE [31m512[0m bits
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mDHE-RSA-CAMELLIA128-SHA      [0m DHE [31m512[0m bits
+Accepted  [33mTLSv1.0[0m  [33m112[0m bits  [33mECDHE-RSA-DES-CBC3-SHA       [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.0[0m  [33m112[0m bits  [33mDHE-RSA-DES-CBC3-SHA         [0m DHE [31m512[0m bits
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mAES256-SHA                   [0m
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mCAMELLIA256-SHA              [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mAES128-SHA                   [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mCAMELLIA128-SHA              [0m
+Accepted  [33mTLSv1.0[0m  [33m112[0m bits  [33mDES-CBC3-SHA                 [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [31mTLS_RSA_WITH_RC4_128_MD5     [0m
 Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_RSA_WITH_RC4_128_SHA     [0m
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  TLS_RSA_WITH_IDEA_CBC_SHA    
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_RSA_WITH_IDEA_CBC_SHA    [0m
 Accepted  [33mTLSv1.0[0m  [31m56[0m bits   [33mTLS_RSA_WITH_DES_CBC_SHA     [0m
 Accepted  [33mTLSv1.0[0m  [31m56[0m bits   [33mTLS_DHE_RSA_WITH_DES_CBC_SHA [0m
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  TLS_RSA_WITH_SEED_CBC_SHA    
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  TLS_DHE_RSA_WITH_SEED_CBC_SHA
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_RSA_WITH_SEED_CBC_SHA    [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_DHE_RSA_WITH_SEED_CBC_SHA[0m
 Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_ECDHE_RSA_WITH_RC4_128_SHA[0m
 
   [1;34mServer Key Exchange Group(s):[0m

--- a/docker_test/expected_output/test_8.txt
+++ b/docker_test/expected_output/test_8.txt
@@ -24,49 +24,49 @@ Compression [31menabled[0m (CRIME)
 TLSv1.0 [32mnot vulnerable[0m to heartbleed
 
   [1;34mSupported Server Cipher(s):[0m
-[32mPreferred[0m [33mTLSv1.0[0m  [32m256[0m bits  ECDHE-RSA-AES256-SHA          Curve P-256 DHE 256
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  DHE-RSA-AES256-SHA            DHE [31m512[0m bits
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  DHE-RSA-CAMELLIA256-SHA       DHE [31m512[0m bits
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [35mAECDH-AES256-SHA             [0m Curve P-256 DHE 256
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [35mADH-AES256-SHA               [0m DHE [31m512[0m bits
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [35mADH-CAMELLIA256-SHA          [0m DHE [31m512[0m bits
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  ECDHE-RSA-AES128-SHA          Curve P-256 DHE 256
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  DHE-RSA-AES128-SHA            DHE [31m512[0m bits
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  DHE-RSA-CAMELLIA128-SHA       DHE [31m512[0m bits
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [35mAECDH-AES128-SHA             [0m Curve P-256 DHE 256
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [35mADH-AES128-SHA               [0m DHE [31m512[0m bits
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [35mADH-CAMELLIA128-SHA          [0m DHE [31m512[0m bits
-Accepted  [33mTLSv1.0[0m  [32m112[0m bits  [33mECDHE-RSA-DES-CBC3-SHA       [0m Curve P-256 DHE 256
-Accepted  [33mTLSv1.0[0m  [32m112[0m bits  [33mDHE-RSA-DES-CBC3-SHA         [0m DHE [31m512[0m bits
-Accepted  [33mTLSv1.0[0m  [32m112[0m bits  [35mAECDH-DES-CBC3-SHA           [0m Curve P-256 DHE 256
-Accepted  [33mTLSv1.0[0m  [32m112[0m bits  [35mADH-DES-CBC3-SHA             [0m DHE [31m512[0m bits
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  AES256-SHA                   
-Accepted  [33mTLSv1.0[0m  [32m256[0m bits  CAMELLIA256-SHA              
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  AES128-SHA                   
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  CAMELLIA128-SHA              
-Accepted  [33mTLSv1.0[0m  [32m112[0m bits  [33mDES-CBC3-SHA                 [0m
+[32mPreferred[0m [33mTLSv1.0[0m  [32m256[0m bits  [33mECDHE-RSA-AES256-SHA         [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mDHE-RSA-AES256-SHA           [0m DHE [31m512[0m bits
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mDHE-RSA-CAMELLIA256-SHA      [0m DHE [31m512[0m bits
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [41mAECDH-AES256-SHA             [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [41mADH-AES256-SHA               [0m DHE [31m512[0m bits
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [41mADH-CAMELLIA256-SHA          [0m DHE [31m512[0m bits
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mECDHE-RSA-AES128-SHA         [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mDHE-RSA-AES128-SHA           [0m DHE [31m512[0m bits
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mDHE-RSA-CAMELLIA128-SHA      [0m DHE [31m512[0m bits
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [41mAECDH-AES128-SHA             [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [41mADH-AES128-SHA               [0m DHE [31m512[0m bits
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [41mADH-CAMELLIA128-SHA          [0m DHE [31m512[0m bits
+Accepted  [33mTLSv1.0[0m  [33m112[0m bits  [33mECDHE-RSA-DES-CBC3-SHA       [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.0[0m  [33m112[0m bits  [33mDHE-RSA-DES-CBC3-SHA         [0m DHE [31m512[0m bits
+Accepted  [33mTLSv1.0[0m  [33m112[0m bits  [41mAECDH-DES-CBC3-SHA           [0m Curve P-256 DHE 256
+Accepted  [33mTLSv1.0[0m  [33m112[0m bits  [41mADH-DES-CBC3-SHA             [0m DHE [31m512[0m bits
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mAES256-SHA                   [0m
+Accepted  [33mTLSv1.0[0m  [32m256[0m bits  [33mCAMELLIA256-SHA              [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mAES128-SHA                   [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mCAMELLIA128-SHA              [0m
+Accepted  [33mTLSv1.0[0m  [33m112[0m bits  [33mDES-CBC3-SHA                 [0m
 Accepted  [33mTLSv1.0[0m  [41m0[0m bits    [41mECDHE-RSA-NULL-SHA           [0m Curve P-256 DHE 256
 Accepted  [33mTLSv1.0[0m  [41m0[0m bits    [41mAECDH-NULL-SHA               [0m Curve P-256 DHE 256
 Accepted  [33mTLSv1.0[0m  [41m0[0m bits    [41mNULL-SHA                     [0m
 Accepted  [33mTLSv1.0[0m  [41m0[0m bits    [41mNULL-MD5                     [0m
 Accepted  [33mTLSv1.0[0m  [31m40[0m bits   [31mTLS_RSA_EXPORT_WITH_RC4_40_MD5[0m
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_RSA_WITH_RC4_128_MD5     [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [31mTLS_RSA_WITH_RC4_128_MD5     [0m
 Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_RSA_WITH_RC4_128_SHA     [0m
 Accepted  [33mTLSv1.0[0m  [31m40[0m bits   [31mTLS_RSA_EXPORT_WITH_RC2_CBC_40_MD5[0m
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  TLS_RSA_WITH_IDEA_CBC_SHA    
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_RSA_WITH_IDEA_CBC_SHA    [0m
 Accepted  [33mTLSv1.0[0m  [31m40[0m bits   [31mTLS_RSA_EXPORT_WITH_DES40_CBC_SHA[0m
 Accepted  [33mTLSv1.0[0m  [31m56[0m bits   [33mTLS_RSA_WITH_DES_CBC_SHA     [0m
 Accepted  [33mTLSv1.0[0m  [31m40[0m bits   [31mTLS_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA[0m
 Accepted  [33mTLSv1.0[0m  [31m56[0m bits   [33mTLS_DHE_RSA_WITH_DES_CBC_SHA [0m
-Accepted  [33mTLSv1.0[0m  [31m40[0m bits   [35mTLS_DH_anon_EXPORT_WITH_RC4_40_MD5[0m
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [35mTLS_DH_anon_WITH_RC4_128_MD5 [0m
-Accepted  [33mTLSv1.0[0m  [31m40[0m bits   [35mTLS_DH_anon_EXPORT_WITH_DES40_CBC_SHA[0m
-Accepted  [33mTLSv1.0[0m  [31m56[0m bits   [35mTLS_DH_anon_WITH_DES_CBC_SHA [0m
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  TLS_RSA_WITH_SEED_CBC_SHA    
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  TLS_DHE_RSA_WITH_SEED_CBC_SHA
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [35mTLS_DH_anon_WITH_SEED_CBC_SHA[0m
+Accepted  [33mTLSv1.0[0m  [31m40[0m bits   [41mTLS_DH_anon_EXPORT_WITH_RC4_40_MD5[0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [41mTLS_DH_anon_WITH_RC4_128_MD5 [0m
+Accepted  [33mTLSv1.0[0m  [31m40[0m bits   [41mTLS_DH_anon_EXPORT_WITH_DES40_CBC_SHA[0m
+Accepted  [33mTLSv1.0[0m  [31m56[0m bits   [41mTLS_DH_anon_WITH_DES_CBC_SHA [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_RSA_WITH_SEED_CBC_SHA    [0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_DHE_RSA_WITH_SEED_CBC_SHA[0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [41mTLS_DH_anon_WITH_SEED_CBC_SHA[0m
 Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [33mTLS_ECDHE_RSA_WITH_RC4_128_SHA[0m
-Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [35mTLS_ECDH_anon_WITH_RC4_128_SHA[0m
+Accepted  [33mTLSv1.0[0m  [32m128[0m bits  [41mTLS_ECDH_anon_WITH_RC4_128_SHA[0m
 
   [1;34mServer Key Exchange Group(s):[0m
 TLSv1.0  [32m128[0m bits  secp256r1 (NIST P-256)[0m

--- a/docker_test/expected_output/test_9.txt
+++ b/docker_test/expected_output/test_9.txt
@@ -8,17 +8,52 @@ SSLv2     [32mdisabled[0m
 SSLv3     [32mdisabled[0m
 TLSv1.0   [32mdisabled[0m
 TLSv1.1   [32mdisabled[0m
-TLSv1.2   enabled
-TLSv1.3   [33mdisabled[0m
+TLSv1.2   disabled
+TLSv1.3   [32menabled[0m
+
+  [1;34mTLS Fallback SCSV:[0m
+Server [32msupports[0m TLS Fallback SCSV
+
+  [1;34mTLS renegotiation:[0m
+Session renegotiation [32mnot supported[0m
+
+  [1;34mTLS Compression:[0m
+Compression [32mdisabled[0m
+
+  [1;34mHeartbleed:[0m
+TLSv1.3 [32mnot vulnerable[0m to heartbleed
 
   [1;34mSupported Server Cipher(s):[0m
-[32mPreferred[0m 200 OK           TLSv1.2  [32m256[0m bits  [32mECDHE-RSA-CHACHA20-POLY1305  [0m Curve [32m25519[0m DHE 253
+[32mPreferred[0m [32mTLSv1.3[0m  [32m128[0m bits  [32mTLS_AES_128_GCM_SHA256       [0m
+Accepted  [32mTLSv1.3[0m  [32m256[0m bits  [32mTLS_AES_256_GCM_SHA384       [0m
+Accepted  [32mTLSv1.3[0m  [32m256[0m bits  [32mTLS_CHACHA20_POLY1305_SHA256 [0m
+
+  [1;34mServer Key Exchange Group(s):[0m
+TLSv1.3  [32m128[0m bits  secp256r1 (NIST P-256)[0m
+TLSv1.3  [32m192[0m bits  secp384r1 (NIST P-384)[0m
+TLSv1.3  [32m260[0m bits  secp521r1 (NIST P-521)[0m
+TLSv1.3  [32m128[0m bits  [32mx25519[0m
+TLSv1.3  [32m224[0m bits  [32mx448[0m
+TLSv1.3  [32m128[0m bits  brainpoolP256r1tls13[0m
+TLSv1.3  [32m192[0m bits  brainpoolP384r1tls13[0m
+TLSv1.3  [32m256[0m bits  brainpoolP512r1tls13[0m
+TLSv1.3  [32m112[0m bits  ffdhe2048[0m
+TLSv1.3  [32m128[0m bits  ffdhe3072[0m
+TLSv1.3  [32m150[0m bits  ffdhe4096[0m
+TLSv1.3  [32m175[0m bits  ffdhe6144[0m
+TLSv1.3  [32m192[0m bits  ffdhe8192[0m
+TLSv1.3  [32m128[0m bits  [33mMLKEM512[0m
+TLSv1.3  [32m192[0m bits  [33mMLKEM768[0m
+TLSv1.3  [32m256[0m bits  [33mMLKEM1024[0m
+TLSv1.3  [32m192[0m bits  SecP256r1MLKEM768[0m
+TLSv1.3  [32m192[0m bits  [32mX25519MLKEM768[0m
+TLSv1.3  [32m256[0m bits  SecP384r1MLKEM1024[0m
 
   [1;34mSSL Certificate:[0m
 Signature Algorithm: [32msha256WithRSAEncryption[0m
-RSA Key Strength:    3072
+RSA Key Strength:    [32m3072[0m
 
 Subject:  lmgtfy.com
-Issuer:   /C=XX/ST=Nowhere in particular/L=Nowhere
+Issuer:   /C=XX/ST=Nowhere in particular/L=Nowhere[0m
 Not valid before: [32mDec  3 04:07:43 2019 GMT[0m
 Not valid after:  [32mDec  3 04:07:43 2029 GMT[0m


### PR DESCRIPTION
This PR updates the tests after the coloring changes made in #333.  It also updates the build system so that the target applications are built inside a container (hence, building becomes much more reliable vs compiling on a very wide variety of host systems).  Lastly, new tests were added against OpenSSL v3.5.0 and GnuTLS v3.8.9 which target the new PQ algorithms and TLS groups added in #331.

The new test image will be automatically created the next time `docker_test.sh` is run.  Note that this will take 15+ minutes since many versions of OpenSSL and GnuTLS are built.