### PR TITLE
Update coloring of the number of bits of groups to yellow when bits is greater or equal to 112 and less than 128

### DIFF
--- a/sslscan.c
+++ b/sslscan.c
@@ -6046,6 +6046,8 @@ int testSupportedGroups(struct sslCheckOptions *options) {
       char *bits_color = RESET;
       if (group_bit_strength < 112)
         bits_color = COL_RED;
+      else if (group_bit_strength < 128)
+        bits_color = COL_YELLOW;
       else
         bits_color = COL_GREEN;
 


### PR DESCRIPTION
Without this PR, a line like `TLSv1.3  112 bits  ffdhe2048` will display `ffdhe2048` in yellow, but the `112` is in green.  With this PR, both those fields are now yellow.

I missed this since our Docker test system is still in limbo until #336 lands.