### PR TITLE
Update color of CCM8 ciphers to red to match the color of the bit strength

### DIFF
--- a/sslscan.c
+++ b/sslscan.c
@@ -1697,16 +1697,16 @@ void outputCipher(struct sslCheckOptions *options, SSL *ssl, const char *cleanSs
             printf("%s%-29s%s", COL_YELLOW, ciphername, RESET);
         }
         strength = "medium";
-    } else if (strstr(ciphername, "CCM8")) {
+    } else if (strstr(ciphername, "CCM8") || strstr(ciphername, "CCM_8")) {
         // Short authentication tag length
         // These are flagged as 64 bit strength in newer versions of OpenSSL
         // But in older versions they'll still show as 256 bits, so manually flag them here
         // See https://github.com/openssl/openssl/pull/16652
         if (options->ianaNames) {
-            printf("%s%-45s%s", COL_YELLOW, ciphername, RESET);
+            printf("%s%-45s%s", COL_RED, ciphername, RESET);
         }
         else {
-            printf("%s%-29s%s", COL_YELLOW, ciphername, RESET);
+            printf("%s%-29s%s", COL_RED, ciphername, RESET);
         }
         strength = "medium";
     } else if (strstr(ciphername, "_SM4_")) { /* Developed by Chinese government */


### PR DESCRIPTION
Also, colorize ciphers named CCM_8 (i.e.: the IANA name used in TLS 1.3).

Before this PR, something like `Accepted  TLSv1.2  64 bits   DHE-RSA-AES128-CCM8` was printing the `64` in red, but `DHE-RSA-AES128-CCM8` was yellow.  After this PR, both of those fields are red.