### PR TITLE
Display negotiated TLS 1.3 group name

### DIFF
--- a/sslscan.c
+++ b/sslscan.c
@@ -1497,7 +1497,13 @@ int ssl_print_tmp_key(struct sslCheckOptions *options, SSL *s)
 #ifndef LIBRESSL_VERSION_NUMBER
     EVP_PKEY *key;
     if (!SSL_get_server_tmp_key(s, &key))
+    {
+        if (SSL_version(s) == TLS1_3_VERSION)
+        {
+            printf(" Group %s", SSL_group_to_name(s, SSL_get_negotiated_group(s)));
+        }
         return 1;
+    }
     switch (EVP_PKEY_id(key)) {
     case EVP_PKEY_RSA:
         if (EVP_PKEY_bits(key) <= 1024)


### PR DESCRIPTION
I noticed that "Supported Server Cipher(s):" section would list the negotiated DHE group/curve but not hybrid PQCs:

```
  Supported Server Cipher(s):
Preferred TLSv1.3  256 bits  TLS_CHACHA20_POLY1305_SHA256 
Accepted  TLSv1.3  128 bits  TLS_AES_128_GCM_SHA256       
Accepted  TLSv1.3  256 bits  TLS_AES_256_GCM_SHA384       
Preferred TLSv1.2  256 bits  ECDHE-RSA-CHACHA20-POLY1305   Curve 25519 DHE 253
Accepted  TLSv1.2  128 bits  ECDHE-RSA-AES128-GCM-SHA256   Curve 25519 DHE 253
Accepted  TLSv1.2  256 bits  ECDHE-RSA-AES256-GCM-SHA384   Curve 25519 DHE 253
```

So I added support for it:
```
  Supported Server Cipher(s):
Preferred TLSv1.3  256 bits  TLS_CHACHA20_POLY1305_SHA256  Group X25519MLKEM768
Accepted  TLSv1.3  128 bits  TLS_AES_128_GCM_SHA256        Group X25519MLKEM768
Accepted  TLSv1.3  256 bits  TLS_AES_256_GCM_SHA384        Group X25519MLKEM768
Preferred TLSv1.2  256 bits  ECDHE-RSA-CHACHA20-POLY1305   Curve 25519 DHE 253
Accepted  TLSv1.2  128 bits  ECDHE-RSA-AES128-GCM-SHA256   Curve 25519 DHE 253
Accepted  TLSv1.2  256 bits  ECDHE-RSA-AES256-GCM-SHA384   Curve 25519 DHE 253
```

I considered trying to colorize the group name but I decided against it because:
1. The OpenSSL API is a little weird here. These "NIDs" are actually `TLSEXT_nid_unknown | IANA_registry_id`. I'm not sure what to make of that or if it will change in the future.
2. That would require duplicating the colorization rules from elsewhere in the code.
