### PR TITLE
Add missing newline in version output

### DIFF
--- a/sslscan.c
+++ b/sslscan.c
@@ -4155,7 +4155,7 @@ int main(int argc, char *argv[])
     switch (mode)
     {
         case mode_version:
-            printf("%s\n%s", VERSION, OpenSSL_version(OPENSSL_VERSION));
+            printf("%s\n%s\n", VERSION, OpenSSL_version(OPENSSL_VERSION));
             break;
 
         case mode_help:


### PR DESCRIPTION
The `--version` output was missing a newline and messing up my shell prompt.