### PR TITLE
Accept --sleep <ms> in addition to --sleep=<ms>

### DIFF
--- a/sslscan.c
+++ b/sslscan.c
@@ -3997,10 +3997,24 @@ int main(int argc, char *argv[])
         else if (strncmp("--connect-timeout=", argv[argLoop], 18) == 0)
             options->connect_timeout = atoi(argv[argLoop] + 18);
 
-        // Sleep between requests (ms)
+        // Sleep between requests (ms). Accept both `--sleep=<ms>` and
+        // `--sleep <ms>` (issue #357 — the latter form silently did nothing).
         else if (strncmp("--sleep=", argv[argLoop], 8) == 0)
         {
             msec = atoi(argv[argLoop] + 8);
+            if (msec >= 0) {
+                options->sleep = msec;
+            }
+        }
+        else if (strcmp("--sleep", argv[argLoop]) == 0)
+        {
+            if (argLoop + 1 >= argc)
+            {
+                printf("%s--sleep%s requires a value in milliseconds (e.g. --sleep 100 or --sleep=100)\n", COL_RED, RESET);
+                exit(1);
+            }
+            argLoop++;
+            msec = atoi(argv[argLoop]);
             if (msec >= 0) {
                 options->sleep = msec;
             }


### PR DESCRIPTION
Closes #357.

`--sleep` is the only common rate-limiting flag in sslscan and the manual arg parser only matched the `strncmp("--sleep=", ...)` form. The space-separated form `--sleep <ms>` silently fell through to the next else-if (and was eventually treated as an unrecognized argument or as a hostname), so users who tried `--sleep 100` saw it appear to have no effect — that's exactly the confusion the issue describes.

### Fix
Add a parallel `else if (strcmp("--sleep", argv[argLoop]) == 0)` branch that advances `argLoop` to consume the value, `atoi`-parses it, and sets `options->sleep` using the same `>=0` guard as the existing branch. If the user passes `--sleep` with no following argument, print a friendly error pointing at both working forms:

```
$ ./sslscan --sleep
--sleep requires a value in milliseconds (e.g. --sleep 100 or --sleep=100)
```

### Verification

End-to-end timing against `example.com` confirms both forms now sleep identically:

```
$ python3 -c "..." # measure wall-clock for each
--- baseline (no --sleep) ---  0.26s
--- --sleep=200 (existing) ---  2.49s
--- --sleep 200 (was broken)--- 2.51s
```

The build is clean against system OpenSSL on Linux:

```
$ make
Building against system OpenSSL...
$ ls -la sslscan
-rwxrwxr-x ... sslscan
```

I scoped this fix to `--sleep` only (the issue) rather than reworking the whole arg parser to handle both `--option value` and `--option=value` for every flag — happy to extend the pattern if you'd prefer it consistent across all options.